### PR TITLE
fix: Pump to 6.7.0 version for generator-hipster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,37 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@babel/runtime": {
-            "version": "7.7.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-            "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+        "@babel/code-frame": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
             "requires": {
-                "regenerator-runtime": "0.13.3"
+                "@babel/highlight": "^7.8.3"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+            "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+                }
+            }
+        },
+        "@babel/runtime": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+            "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+            "requires": {
+                "regenerator-runtime": "^0.13.2"
             }
         },
         "@mrmlnc/readdir-enhanced": {
@@ -17,8 +42,8 @@
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
             "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
             "requires": {
-                "call-me-maybe": "1.0.1",
-                "glob-to-regexp": "0.3.0"
+                "call-me-maybe": "^1.0.1",
+                "glob-to-regexp": "^0.3.0"
             }
         },
         "@nodelib/fs.stat": {
@@ -55,9 +80,9 @@
             "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
             "dev": true,
             "requires": {
-                "@sinonjs/commons": "1.7.0",
-                "array-from": "2.1.1",
-                "lodash": "4.17.15"
+                "@sinonjs/commons": "^1.3.0",
+                "array-from": "^2.1.1",
+                "lodash": "^4.17.15"
             },
             "dependencies": {
                 "lodash": {
@@ -79,26 +104,51 @@
             "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
             "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
             "requires": {
-                "@types/node": "10.17.13"
+                "@types/node": "*"
             }
+        },
+        "@types/events": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
         },
         "@types/form-data": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
             "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
             "requires": {
-                "@types/node": "10.17.13"
+                "@types/node": "*"
             }
         },
+        "@types/glob": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+            "requires": {
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+        },
         "@types/node": {
-            "version": "10.17.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-            "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
+            "version": "10.17.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+            "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+        },
+        "@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
         },
         "@types/qs": {
-            "version": "6.9.0",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.0.tgz",
-            "integrity": "sha512-c4zji5CjWv1tJxIZkz1oUtGcdOlsH3aza28Nqmm+uNDWBRHoMsjooBEN4czZp1V3iXPihE/VRUOBqg+4Xq0W4g=="
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
+            "integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw=="
         },
         "acorn": {
             "version": "7.1.0",
@@ -118,9 +168,9 @@
             "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
             "dev": true,
             "requires": {
-                "acorn": "7.1.0",
-                "acorn-walk": "7.0.0",
-                "xtend": "4.0.2"
+                "acorn": "^7.0.0",
+                "acorn-walk": "^7.0.0",
+                "xtend": "^4.0.2"
             }
         },
         "acorn-walk": {
@@ -130,12 +180,19 @@
             "dev": true
         },
         "aggregate-error": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-1.0.0.tgz",
-            "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+            "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
             "requires": {
-                "clean-stack": "1.3.0",
-                "indent-string": "3.2.0"
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "dependencies": {
+                "indent-string": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+                    "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+                }
             }
         },
         "ajv": {
@@ -143,10 +200,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
             "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
             "requires": {
-                "fast-deep-equal": "2.0.1",
-                "fast-json-stable-stringify": "2.1.0",
-                "json-schema-traverse": "0.4.1",
-                "uri-js": "4.2.2"
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "ajv-keywords": {
@@ -165,7 +222,7 @@
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.0.0"
             }
         },
         "ansi-cyan": {
@@ -199,7 +256,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "requires": {
-                "color-convert": "1.9.3"
+                "color-convert": "^1.9.0"
             }
         },
         "ansi-wrap": {
@@ -212,8 +269,8 @@
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
             "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.7"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
             }
         },
         "argparse": {
@@ -221,7 +278,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -229,8 +286,8 @@
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
@@ -269,7 +326,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -297,7 +354,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "assert-plus": {
@@ -326,7 +383,7 @@
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
             "requires": {
-                "lodash": "4.17.15"
+                "lodash": "^4.17.14"
             },
             "dependencies": {
                 "lodash": {
@@ -385,7 +442,7 @@
             "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
             "requires": {
                 "follow-redirects": "1.5.10",
-                "is-buffer": "2.0.4"
+                "is-buffer": "^2.0.2"
             }
         },
         "babel-code-frame": {
@@ -394,9 +451,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.3",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -417,11 +474,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -430,7 +487,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -457,13 +514,13 @@
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.3.0",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.2",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -471,7 +528,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -479,7 +536,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -487,7 +544,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -495,9 +552,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "kind-of": {
@@ -517,7 +574,7 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "bin-version": {
@@ -525,8 +582,8 @@
             "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-2.0.0.tgz",
             "integrity": "sha1-LMldg7Uive8umZeOdq61SRyBFP8=",
             "requires": {
-                "execa": "0.1.1",
-                "find-versions": "2.0.0"
+                "execa": "^0.1.1",
+                "find-versions": "^2.0.0"
             },
             "dependencies": {
                 "execa": {
@@ -534,9 +591,9 @@
                     "resolved": "https://registry.npmjs.org/execa/-/execa-0.1.1.tgz",
                     "integrity": "sha1-sJwqkwm8DvBQFHlHLbMYD41MPt0=",
                     "requires": {
-                        "cross-spawn-async": "2.2.5",
-                        "object-assign": "4.1.1",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn-async": "^2.1.1",
+                        "object-assign": "^4.0.1",
+                        "strip-eof": "^1.0.0"
                     }
                 }
             }
@@ -546,9 +603,9 @@
             "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-3.0.0.tgz",
             "integrity": "sha1-4k6/prY8sDh8X8F0+G5cyBLKfMk=",
             "requires": {
-                "bin-version": "2.0.0",
-                "semver": "5.5.0",
-                "semver-truncate": "1.1.2"
+                "bin-version": "^2.0.0",
+                "semver": "^5.1.0",
+                "semver-truncate": "^1.0.0"
             }
         },
         "binaryextensions": {
@@ -572,13 +629,13 @@
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
             "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
             "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.4.1",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.1"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
             }
         },
         "brace-expansion": {
@@ -586,7 +643,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -595,16 +652,16 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.3",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -612,7 +669,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -628,9 +685,9 @@
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "requires": {
-                "base64-js": "1.3.1",
-                "ieee754": "1.1.13",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
         "buffer-alloc": {
@@ -638,8 +695,8 @@
             "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "requires": {
-                "buffer-alloc-unsafe": "1.1.0",
-                "buffer-fill": "1.0.0"
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
             }
         },
         "buffer-alloc-unsafe": {
@@ -662,15 +719,15 @@
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.3.0",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.1",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.1",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "cacheable-request": {
@@ -710,7 +767,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsites": {
@@ -729,9 +786,9 @@
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
             "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
             "requires": {
-                "camelcase": "4.1.0",
-                "map-obj": "2.0.0",
-                "quick-lru": "1.1.0"
+                "camelcase": "^4.1.0",
+                "map-obj": "^2.0.0",
+                "quick-lru": "^1.0.0"
             }
         },
         "capture-stack-trace": {
@@ -750,7 +807,7 @@
             "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.15"
+                "lodash": "^4.17.14"
             },
             "dependencies": {
                 "lodash": {
@@ -767,12 +824,12 @@
             "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
             "dev": true,
             "requires": {
-                "assertion-error": "1.1.0",
-                "check-error": "1.0.2",
-                "deep-eql": "3.0.1",
-                "get-func-name": "2.0.0",
-                "pathval": "1.1.0",
-                "type-detect": "4.0.8"
+                "assertion-error": "^1.0.1",
+                "check-error": "^1.0.1",
+                "deep-eql": "^3.0.0",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.0.0",
+                "type-detect": "^4.0.0"
             }
         },
         "chalk": {
@@ -780,9 +837,9 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "chardet": {
@@ -820,10 +877,10 @@
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "arr-union": {
@@ -836,15 +893,15 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
         },
         "clean-stack": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-            "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
         },
         "cli-boxes": {
             "version": "1.0.0",
@@ -856,7 +913,7 @@
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-list": {
@@ -895,9 +952,9 @@
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -912,7 +969,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -921,9 +978,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -932,7 +989,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 }
             }
@@ -952,8 +1009,8 @@
             "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
             "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
             "requires": {
-                "is-regexp": "1.0.0",
-                "is-supported-regexp-flag": "1.0.1"
+                "is-regexp": "^1.0.0",
+                "is-supported-regexp-flag": "^1.0.0"
             }
         },
         "clone-response": {
@@ -961,7 +1018,7 @@
             "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
             "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
             "requires": {
-                "mimic-response": "1.0.1"
+                "mimic-response": "^1.0.0"
             }
         },
         "clone-stats": {
@@ -974,9 +1031,9 @@
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
             "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
             "requires": {
-                "inherits": "2.0.4",
-                "process-nextick-args": "2.0.1",
-                "readable-stream": "2.3.7"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "code-point-at": {
@@ -989,8 +1046,8 @@
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color": {
@@ -998,8 +1055,8 @@
             "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
             "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
             "requires": {
-                "color-convert": "1.9.3",
-                "color-string": "1.5.3"
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
             }
         },
         "color-convert": {
@@ -1020,8 +1077,8 @@
             "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
             "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
             "requires": {
-                "color-name": "1.1.3",
-                "simple-swizzle": "0.2.2"
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
             }
         },
         "colornames": {
@@ -1039,8 +1096,8 @@
             "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
             "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
             "requires": {
-                "color": "3.0.0",
-                "text-hex": "1.0.0"
+                "color": "3.0.x",
+                "text-hex": "1.0.x"
             }
         },
         "combined-stream": {
@@ -1048,7 +1105,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -1076,10 +1133,10 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "requires": {
-                "buffer-from": "1.1.1",
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "conf": {
@@ -1087,11 +1144,11 @@
             "resolved": "https://registry.npmjs.org/conf/-/conf-2.2.0.tgz",
             "integrity": "sha512-93Kz74FOMo6aWRVpAZsonOdl2I57jKtHrNmxhumehFQw4X8Sk37SohNY11PG7Q8Okta+UnrVaI006WLeyp8/XA==",
             "requires": {
-                "dot-prop": "4.2.0",
-                "env-paths": "1.0.0",
-                "make-dir": "1.3.0",
-                "pkg-up": "2.0.0",
-                "write-file-atomic": "2.4.3"
+                "dot-prop": "^4.1.0",
+                "env-paths": "^1.0.0",
+                "make-dir": "^1.0.0",
+                "pkg-up": "^2.0.0",
+                "write-file-atomic": "^2.3.0"
             }
         },
         "config-chain": {
@@ -1099,8 +1156,8 @@
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
             "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
             "requires": {
-                "ini": "1.3.5",
-                "proto-list": "1.2.4"
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
             }
         },
         "configstore": {
@@ -1108,12 +1165,12 @@
             "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
             "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
             "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.2.3",
-                "make-dir": "1.3.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.4.3",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "contains-path": {
@@ -1128,9 +1185,9 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
         "core-js": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.2.tgz",
-            "integrity": "sha512-hIE5dXkRzRvnZ5vhkRfQxUvDxQZmD9oueA08jDYRBKJHx+VIl/Pne/e0A4x9LObEEthC/TqiZybUoNM4tRgnKg=="
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+            "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -1142,7 +1199,7 @@
             "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "requires": {
-                "capture-stack-trace": "1.0.1"
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "cross-spawn": {
@@ -1150,11 +1207,11 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "requires": {
-                "nice-try": "1.0.5",
-                "path-key": "2.0.1",
-                "semver": "5.5.0",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "cross-spawn-async": {
@@ -1162,8 +1219,8 @@
             "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
             "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
             "requires": {
-                "lru-cache": "4.1.5",
-                "which": "1.3.1"
+                "lru-cache": "^4.0.0",
+                "which": "^1.2.8"
             }
         },
         "crypto-random-string": {
@@ -1176,7 +1233,7 @@
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "cycle": {
@@ -1194,7 +1251,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "dateformat": {
@@ -1220,8 +1277,8 @@
             "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
             "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
             "requires": {
-                "decamelize": "1.2.0",
-                "map-obj": "1.0.1"
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
             },
             "dependencies": {
                 "map-obj": {
@@ -1241,7 +1298,7 @@
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
             "requires": {
-                "mimic-response": "1.0.1"
+                "mimic-response": "^1.0.0"
             }
         },
         "deep-eql": {
@@ -1250,7 +1307,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "4.0.8"
+                "type-detect": "^4.0.0"
             }
         },
         "deep-extend": {
@@ -1274,7 +1331,7 @@
             "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "requires": {
-                "clone": "1.0.4"
+                "clone": "^1.0.2"
             }
         },
         "define-properties": {
@@ -1282,7 +1339,7 @@
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "requires": {
-                "object-keys": "1.1.1"
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1290,8 +1347,8 @@
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -1299,7 +1356,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1307,7 +1364,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1315,9 +1372,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "kind-of": {
@@ -1352,9 +1409,9 @@
             "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
             "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
             "requires": {
-                "colorspace": "1.1.2",
-                "enabled": "1.0.2",
-                "kuler": "1.0.1"
+                "colorspace": "1.1.x",
+                "enabled": "1.0.x",
+                "kuler": "1.0.x"
             }
         },
         "didyoumean": {
@@ -1372,8 +1429,8 @@
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "requires": {
-                "arrify": "1.0.1",
-                "path-type": "3.0.0"
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
             }
         },
         "doctrine": {
@@ -1382,7 +1439,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.3"
+                "esutils": "^2.0.2"
             }
         },
         "dot-prop": {
@@ -1390,7 +1447,7 @@
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
             "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "downgrade-root": {
@@ -1398,8 +1455,8 @@
             "resolved": "https://registry.npmjs.org/downgrade-root/-/downgrade-root-1.2.2.tgz",
             "integrity": "sha1-UxMZcVsOgf/MIusoR4uidkPhLGw=",
             "requires": {
-                "default-uid": "1.0.0",
-                "is-root": "1.0.0"
+                "default-uid": "^1.0.0",
+                "is-root": "^1.0.0"
             }
         },
         "drange": {
@@ -1417,8 +1474,8 @@
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "editions": {
@@ -1426,8 +1483,8 @@
             "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
             "integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
             "requires": {
-                "errlop": "2.0.0",
-                "semver": "6.3.0"
+                "errlop": "^2.0.0",
+                "semver": "^6.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -1455,12 +1512,12 @@
             "dev": true,
             "requires": {
                 "ejs": "2.5.6",
-                "ejs-include-regex": "1.0.0",
-                "globby": "6.1.0",
-                "read-input": "0.3.1",
-                "rewire": "2.5.2",
-                "syntax-error": "1.4.0",
-                "yargs": "7.1.0"
+                "ejs-include-regex": "^1.0.0",
+                "globby": "^6.1.0",
+                "read-input": "^0.3.1",
+                "rewire": "^2.5.1",
+                "syntax-error": "^1.1.6",
+                "yargs": "^7.0.1"
             },
             "dependencies": {
                 "ejs": {
@@ -1475,11 +1532,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -1495,7 +1552,7 @@
             "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
             "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
             "requires": {
-                "env-variable": "0.0.5"
+                "env-variable": "0.0.x"
             }
         },
         "encodeurl": {
@@ -1508,7 +1565,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "env-paths": {
@@ -1517,9 +1574,9 @@
             "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA="
         },
         "env-variable": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
-            "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+            "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
         },
         "errlop": {
             "version": "2.0.0",
@@ -1531,7 +1588,7 @@
             "resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
             "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
             "requires": {
-                "string-template": "0.2.1"
+                "string-template": "~0.2.1"
             }
         },
         "error-ex": {
@@ -1539,7 +1596,7 @@
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             },
             "dependencies": {
                 "is-arrayish": {
@@ -1555,17 +1612,17 @@
             "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "1.2.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.3",
-                "has-symbols": "1.0.1",
-                "is-callable": "1.1.5",
-                "is-regex": "1.0.5",
-                "object-inspect": "1.7.0",
-                "object-keys": "1.1.1",
-                "object.assign": "4.1.0",
-                "string.prototype.trimleft": "2.1.1",
-                "string.prototype.trimright": "2.1.1"
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.1.5",
+                "is-regex": "^1.0.5",
+                "object-inspect": "^1.7.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.0",
+                "string.prototype.trimleft": "^2.1.1",
+                "string.prototype.trimright": "^2.1.1"
             }
         },
         "es-to-primitive": {
@@ -1574,9 +1631,9 @@
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "dev": true,
             "requires": {
-                "is-callable": "1.1.5",
-                "is-date-object": "1.0.2",
-                "is-symbol": "1.0.3"
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
             }
         },
         "es6-error": {
@@ -1600,44 +1657,44 @@
             "integrity": "sha512-MA0YWJLeK7BPEBxJCINvKnQdKpeTwbac3Xonh0PPFjWYZkowZf+Xl30lJWJ/BWOqFQdAdPcyOh0aBqlbH6ojAg==",
             "dev": true,
             "requires": {
-                "ajv": "6.10.2",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.4.1",
-                "cross-spawn": "6.0.5",
-                "debug": "3.1.0",
-                "doctrine": "2.1.0",
-                "eslint-scope": "4.0.3",
-                "eslint-visitor-keys": "1.1.0",
-                "espree": "4.1.0",
-                "esquery": "1.0.1",
-                "esutils": "2.0.3",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "11.12.0",
-                "ignore": "3.3.10",
-                "imurmurhash": "0.1.4",
-                "inquirer": "5.2.0",
-                "is-resolvable": "1.1.0",
-                "js-yaml": "3.13.1",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.13",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.3",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.3",
-                "regexpp": "1.1.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.5.0",
-                "string.prototype.matchall": "2.0.0",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
-                "table": "4.0.3",
-                "text-table": "0.2.0"
+                "ajv": "^6.5.0",
+                "babel-code-frame": "^6.26.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^4.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.5.0",
+                "ignore": "^3.3.3",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^5.2.0",
+                "is-resolvable": "^1.1.0",
+                "js-yaml": "^3.11.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^1.1.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.0",
+                "string.prototype.matchall": "^2.0.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^4.0.3",
+                "text-table": "^0.2.0"
             }
         },
         "eslint-config-airbnb-base": {
@@ -1646,9 +1703,9 @@
             "integrity": "sha512-hUFXRlE6AY84z0qYh4wKdtSF4EqDnyT8sxrvTpcXCV4ENSLF8li5yNA1yDM26iinH8Ierbpc4lv8Rp62uX6VSQ==",
             "dev": true,
             "requires": {
-                "eslint-restricted-globals": "0.1.1",
-                "object.assign": "4.1.0",
-                "object.entries": "1.1.1"
+                "eslint-restricted-globals": "^0.1.1",
+                "object.assign": "^4.1.0",
+                "object.entries": "^1.0.4"
             }
         },
         "eslint-config-prettier": {
@@ -1657,7 +1714,7 @@
             "integrity": "sha512-QYGfmzuc4q4J6XIhlp8vRKdI/fI0tQfQPy1dME3UOLprE+v4ssH/3W9LM2Q7h5qBcy5m0ehCrBDU2YF8q6OY8w==",
             "dev": true,
             "requires": {
-                "get-stdin": "6.0.0"
+                "get-stdin": "^6.0.0"
             },
             "dependencies": {
                 "get-stdin": {
@@ -1674,8 +1731,8 @@
             "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "resolve": "1.14.2"
+                "debug": "^2.6.9",
+                "resolve": "^1.5.0"
             },
             "dependencies": {
                 "debug": {
@@ -1695,8 +1752,8 @@
             "integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "pkg-dir": "2.0.0"
+                "debug": "^2.6.9",
+                "pkg-dir": "^2.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -1716,16 +1773,16 @@
             "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
             "dev": true,
             "requires": {
-                "contains-path": "0.1.0",
-                "debug": "2.6.9",
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.8",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "0.3.2",
-                "eslint-module-utils": "2.5.0",
-                "has": "1.0.3",
-                "lodash": "4.17.13",
-                "minimatch": "3.0.4",
-                "read-pkg-up": "2.0.0",
-                "resolve": "1.14.2"
+                "eslint-import-resolver-node": "^0.3.1",
+                "eslint-module-utils": "^2.2.0",
+                "has": "^1.0.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.3",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.6.0"
             },
             "dependencies": {
                 "debug": {
@@ -1743,8 +1800,8 @@
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
                     "dev": true,
                     "requires": {
-                        "esutils": "2.0.3",
-                        "isarray": "1.0.0"
+                        "esutils": "^2.0.2",
+                        "isarray": "^1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -1753,10 +1810,10 @@
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.2.3",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "parse-json": {
@@ -1765,7 +1822,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-type": {
@@ -1774,7 +1831,7 @@
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                     "dev": true,
                     "requires": {
-                        "pify": "2.3.0"
+                        "pify": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -1789,9 +1846,9 @@
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.5.0",
-                        "path-type": "2.0.0"
+                        "load-json-file": "^2.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^2.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -1800,8 +1857,8 @@
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "2.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^2.0.0"
                     }
                 }
             }
@@ -1812,7 +1869,7 @@
             "integrity": "sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==",
             "dev": true,
             "requires": {
-                "prettier-linter-helpers": "1.0.0"
+                "prettier-linter-helpers": "^1.0.0"
             }
         },
         "eslint-restricted-globals": {
@@ -1827,8 +1884,8 @@
             "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.3.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "eslint-visitor-keys": {
@@ -1843,9 +1900,9 @@
             "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
             "dev": true,
             "requires": {
-                "acorn": "6.4.0",
-                "acorn-jsx": "5.1.0",
-                "eslint-visitor-keys": "1.1.0"
+                "acorn": "^6.0.2",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
             },
             "dependencies": {
                 "acorn": {
@@ -1867,7 +1924,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "4.3.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -1876,7 +1933,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.3.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -1888,8 +1945,7 @@
         "esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
         },
         "events": {
             "version": "1.1.1",
@@ -1901,13 +1957,13 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
             "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "requires": {
-                "cross-spawn": "6.0.5",
-                "get-stream": "4.1.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "execall": {
@@ -1915,7 +1971,7 @@
             "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
             "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
             "requires": {
-                "clone-regexp": "1.0.1"
+                "clone-regexp": "^1.0.0"
             }
         },
         "exit-hook": {
@@ -1928,13 +1984,13 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "debug": {
@@ -1950,7 +2006,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -1958,7 +2014,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1973,7 +2029,7 @@
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             }
         },
         "external-editor": {
@@ -1981,9 +2037,9 @@
             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.24",
-                "tmp": "0.0.33"
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
             }
         },
         "extglob": {
@@ -1991,14 +2047,14 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2006,7 +2062,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -2014,7 +2070,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2022,7 +2078,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -2030,7 +2086,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -2038,9 +2094,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "kind-of": {
@@ -2081,12 +2137,12 @@
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
             "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
             "requires": {
-                "@mrmlnc/readdir-enhanced": "2.2.1",
-                "@nodelib/fs.stat": "1.1.3",
-                "glob-parent": "3.1.0",
-                "is-glob": "4.0.1",
-                "merge2": "1.3.0",
-                "micromatch": "3.1.10"
+                "@mrmlnc/readdir-enhanced": "^2.2.1",
+                "@nodelib/fs.stat": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "is-glob": "^4.0.0",
+                "merge2": "^1.2.3",
+                "micromatch": "^3.1.10"
             }
         },
         "fast-json-stable-stringify": {
@@ -2115,7 +2171,7 @@
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -2124,8 +2180,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.4",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "fill-range": {
@@ -2133,10 +2189,10 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2144,22 +2200,22 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
         },
         "filter-obj": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-            "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.1.tgz",
+            "integrity": "sha512-yDEp513p7+iLdFHWBVdZFnRiOYwg8ZqmpaAiZCMjzqsbo7tCS4Qm4ulXOht337NGzkukKa9u3W4wqQ9tQPm3Ug=="
         },
         "find-up": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "find-versions": {
@@ -2167,8 +2223,8 @@
             "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-2.0.0.tgz",
             "integrity": "sha1-KtkNSQ9oKMGqQCks9wmsMxghDDw=",
             "requires": {
-                "array-uniq": "1.0.3",
-                "semver-regex": "1.0.0"
+                "array-uniq": "^1.0.0",
+                "semver-regex": "^1.0.0"
             }
         },
         "first-chunk-stream": {
@@ -2176,7 +2232,7 @@
             "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
             "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
             "requires": {
-                "readable-stream": "2.3.7"
+                "readable-stream": "^2.0.2"
             }
         },
         "flat-cache": {
@@ -2185,10 +2241,10 @@
             "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "graceful-fs": "4.2.3",
-                "rimraf": "2.6.3",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
             },
             "dependencies": {
                 "glob": {
@@ -2197,12 +2253,12 @@
                     "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.4",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "rimraf": {
@@ -2211,7 +2267,7 @@
                     "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.6"
+                        "glob": "^7.1.3"
                     }
                 }
             }
@@ -2221,7 +2277,7 @@
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
             "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
             "requires": {
-                "debug": "3.1.0"
+                "debug": "=3.1.0"
             }
         },
         "for-in": {
@@ -2244,9 +2300,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.8",
-                "mime-types": "2.1.26"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -2254,7 +2310,7 @@
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from2": {
@@ -2262,8 +2318,8 @@
             "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "requires": {
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
             }
         },
         "fs-extra": {
@@ -2272,9 +2328,9 @@
             "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.2.3",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -2283,55 +2339,32 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fullname": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/fullname/-/fullname-3.3.0.tgz",
-            "integrity": "sha1-oIdH1pISKWELgXi3YU/OEMsYX1o=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/fullname/-/fullname-4.0.1.tgz",
+            "integrity": "sha512-jVT8q9Ah9JwqfIGKwKzTdbRRthdPpIjEe9kgvxM104Tv+q6SgOAQqJMVP90R0DBRAqejGMHDRWJtl3Ats6BjfQ==",
             "requires": {
-                "execa": "0.6.3",
-                "filter-obj": "1.1.0",
-                "mem": "1.1.0",
-                "p-any": "1.1.0",
-                "p-try": "1.0.0",
-                "passwd-user": "2.1.0",
-                "rc": "1.2.8"
+                "execa": "^1.0.0",
+                "filter-obj": "^2.0.0",
+                "mem": "^5.1.0",
+                "p-any": "^2.1.0",
+                "passwd-user": "^3.0.0",
+                "rc": "^1.2.8"
             },
             "dependencies": {
-                "cross-spawn": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-                    "requires": {
-                        "lru-cache": "4.1.5",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
-                    }
-                },
-                "execa": {
-                    "version": "0.6.3",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
-                    "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
-                    "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                    }
-                },
-                "get-stream": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-                },
                 "mem": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-                    "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz",
+                    "integrity": "sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==",
                     "requires": {
-                        "mimic-fn": "1.2.0"
+                        "map-age-cleaner": "^0.1.3",
+                        "mimic-fn": "^2.1.0",
+                        "p-is-promise": "^2.1.0"
                     }
+                },
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
                 }
             }
         },
@@ -2352,17 +2385,17 @@
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
             "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
             "requires": {
-                "ansi": "0.3.1",
-                "has-unicode": "2.0.1",
-                "lodash.pad": "4.5.1",
-                "lodash.padend": "4.6.1",
-                "lodash.padstart": "4.6.1"
+                "ansi": "^0.3.0",
+                "has-unicode": "^2.0.0",
+                "lodash.pad": "^4.1.0",
+                "lodash.padend": "^4.1.0",
+                "lodash.padstart": "^4.1.0"
             }
         },
         "generator-jhipster": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-6.6.0.tgz",
-            "integrity": "sha512-iaP48cv7wlDCr/Y1r3JqsVbElU3rahgQcTt/2nofTLiJYWUA8Q3xmXlqIhhas5ThFuZlkczKsVv6DtKAvaQArg==",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-6.7.0.tgz",
+            "integrity": "sha512-mWFFbN2rVi9RbqEDhswmxchHReuGczSOL4xkdIp22lDvIZ+pJpiNJHAtxXyYaWkKDff7feecobkt9Qkv2Aq90g==",
             "requires": {
                 "aws-sdk": "2.533.0",
                 "axios": "0.19.0",
@@ -2375,7 +2408,7 @@
                 "glob": "7.1.3",
                 "gulp-filter": "5.1.0",
                 "insight": "0.10.1",
-                "jhipster-core": "6.0.5",
+                "jhipster-core": "6.0.7",
                 "js-object-pretty-print": "0.3.0",
                 "js-yaml": "3.13.1",
                 "lodash": "4.17.13",
@@ -2394,9 +2427,9 @@
                 "tabtab": "2.2.2",
                 "through2": "3.0.1",
                 "uuid": "3.3.3",
-                "yeoman-environment": "2.3.4",
-                "yeoman-generator": "3.2.0",
-                "yo": "3.1.0"
+                "yeoman-environment": "2.7.0",
+                "yeoman-generator": "4.5.0",
+                "yo": "3.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2409,9 +2442,9 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "chardet": {
@@ -2424,9 +2457,9 @@
                     "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
                     "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
                     "requires": {
-                        "chardet": "0.7.0",
-                        "iconv-lite": "0.4.24",
-                        "tmp": "0.0.33"
+                        "chardet": "^0.7.0",
+                        "iconv-lite": "^0.4.24",
+                        "tmp": "^0.0.33"
                     }
                 },
                 "find-up": {
@@ -2434,7 +2467,7 @@
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "requires": {
-                        "locate-path": "3.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
                 "fs-extra": {
@@ -2442,9 +2475,31 @@
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
                     "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
                     "requires": {
-                        "graceful-fs": "4.2.3",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.2"
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                },
+                "gh-got": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+                    "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+                    "requires": {
+                        "got": "^6.2.0",
+                        "is-plain-obj": "^1.1.0"
+                    }
+                },
+                "github-username": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+                    "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+                    "requires": {
+                        "gh-got": "^5.0.0"
                     }
                 },
                 "glob": {
@@ -2452,12 +2507,30 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.4",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "got": {
+                    "version": "6.7.1",
+                    "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                    "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+                    "requires": {
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                     }
                 },
                 "inquirer": {
@@ -2465,19 +2538,19 @@
                     "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
                     "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
                     "requires": {
-                        "ansi-escapes": "3.2.0",
-                        "chalk": "2.4.2",
-                        "cli-cursor": "2.1.0",
-                        "cli-width": "2.2.0",
-                        "external-editor": "3.1.0",
-                        "figures": "2.0.0",
-                        "lodash": "4.17.13",
+                        "ansi-escapes": "^3.2.0",
+                        "chalk": "^2.4.2",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.17.12",
                         "mute-stream": "0.0.7",
-                        "run-async": "2.3.0",
-                        "rxjs": "6.5.4",
-                        "string-width": "2.1.1",
-                        "strip-ansi": "5.2.0",
-                        "through": "2.3.8"
+                        "run-async": "^2.2.0",
+                        "rxjs": "^6.4.0",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^5.1.0",
+                        "through": "^2.3.6"
                     },
                     "dependencies": {
                         "strip-ansi": {
@@ -2485,15 +2558,15 @@
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
                             "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                             "requires": {
-                                "ansi-regex": "4.1.0"
+                                "ansi-regex": "^4.1.0"
                             }
                         }
                     }
                 },
                 "jhipster-core": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-6.0.5.tgz",
-                    "integrity": "sha512-wajVDw31QbqqnVHryqh3EEnmNskKvm7ddGavRx9FcX1Kb+pMIv48y2KbNeYWDyG9HJeZKsrttMWAF7ma+BFTxA==",
+                    "version": "6.0.7",
+                    "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-6.0.7.tgz",
+                    "integrity": "sha512-P6bhyvPxn5ZNIdGcOk4qduPhVDxCW9fXDFte/BVsKlb8FSVeVkV2Sv9FeSGY7LHvFzfHVrtND3TjfWWsTCyNAg==",
                     "requires": {
                         "chevrotain": "6.5.0",
                         "fs-extra": "8.1.0",
@@ -2508,28 +2581,29 @@
                         }
                     }
                 },
-                "js-yaml": {
-                    "version": "3.13.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-                    "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-                    "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "4.0.1"
-                    }
-                },
                 "locate-path": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "requires": {
-                        "p-locate": "3.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
-                "lodash": {
-                    "version": "4.17.13",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-                    "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+                "make-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+                    "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+                    "requires": {
+                        "semver": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "6.3.0",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                        }
+                    }
                 },
                 "minimist": {
                     "version": "1.2.0",
@@ -2546,7 +2620,7 @@
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
                     "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
                     "requires": {
-                        "p-try": "2.2.0"
+                        "p-try": "^2.0.0"
                     }
                 },
                 "p-locate": {
@@ -2554,13 +2628,24 @@
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                     "requires": {
-                        "p-limit": "2.2.2"
+                        "p-limit": "^2.0.0"
                     }
                 },
                 "p-try": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
                     "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+                },
+                "parse-json": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+                    "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
                 },
                 "prettier": {
                     "version": "1.19.1",
@@ -2572,17 +2657,28 @@
                     "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
                     "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
                     "requires": {
-                        "drange": "1.1.1",
-                        "ret": "0.2.2"
+                        "drange": "^1.0.2",
+                        "ret": "^0.2.0"
+                    }
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
                     }
                 },
                 "read-pkg-up": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-                    "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
+                    "integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
                     "requires": {
-                        "find-up": "3.0.0",
-                        "read-pkg": "3.0.0"
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^5.0.0"
                     }
                 },
                 "rxjs": {
@@ -2590,7 +2686,7 @@
                     "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
                     "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
                     "requires": {
-                        "tslib": "1.10.0"
+                        "tslib": "^1.9.0"
                     }
                 },
                 "semver": {
@@ -2603,9 +2699,9 @@
                     "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
                     "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
                     "requires": {
-                        "glob": "7.1.3",
-                        "interpret": "1.2.0",
-                        "rechoir": "0.6.2"
+                        "glob": "^7.0.0",
+                        "interpret": "^1.0.0",
+                        "rechoir": "^0.6.2"
                     }
                 },
                 "through2": {
@@ -2613,61 +2709,61 @@
                     "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
                     "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
                     "requires": {
-                        "readable-stream": "2.3.7"
+                        "readable-stream": "2 || 3"
                     }
                 },
                 "yeoman-environment": {
-                    "version": "2.3.4",
-                    "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.4.tgz",
-                    "integrity": "sha512-KLxE5ft/74Qj7h3AsQZv8G6MEEHYJwmD5F99nfOVaep3rBzCtbrJKkdqWc7bDV141Nr8UZZsIXmzc3IcCm6E2w==",
+                    "version": "2.7.0",
+                    "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.7.0.tgz",
+                    "integrity": "sha512-YNzSUWgJVSgnm0qgLON4Gb2nTm+kywBiWjK4MbvosjUP2YJJ30lNhEx7ukyzKRPUlsavd5IsuALtF6QaVrq81A==",
                     "requires": {
-                        "chalk": "2.4.2",
-                        "cross-spawn": "6.0.5",
-                        "debug": "3.1.0",
-                        "diff": "3.5.0",
-                        "escape-string-regexp": "1.0.5",
-                        "globby": "8.0.2",
-                        "grouped-queue": "0.3.3",
-                        "inquirer": "6.5.2",
-                        "is-scoped": "1.0.0",
-                        "lodash": "4.17.13",
-                        "log-symbols": "2.2.0",
-                        "mem-fs": "1.1.3",
-                        "strip-ansi": "4.0.0",
-                        "text-table": "0.2.0",
-                        "untildify": "3.0.3"
+                        "chalk": "^2.4.1",
+                        "cross-spawn": "^6.0.5",
+                        "debug": "^3.1.0",
+                        "diff": "^3.5.0",
+                        "escape-string-regexp": "^1.0.2",
+                        "globby": "^8.0.1",
+                        "grouped-queue": "^0.3.3",
+                        "inquirer": "^6.0.0",
+                        "is-scoped": "^1.0.0",
+                        "lodash": "^4.17.10",
+                        "log-symbols": "^2.2.0",
+                        "mem-fs": "^1.1.0",
+                        "strip-ansi": "^4.0.0",
+                        "text-table": "^0.2.0",
+                        "untildify": "^3.0.3"
                     }
                 },
                 "yeoman-generator": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-3.2.0.tgz",
-                    "integrity": "sha512-iR/qb2je3GdXtSfxgvOXxUW0Cp8+C6LaZaNlK2BAICzFNzwHtM10t/QBwz5Ea9nk6xVDQNj4Q889TjCXGuIv8w==",
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.5.0.tgz",
+                    "integrity": "sha512-70PbUilZnHV+wKIQ9cz9MmEnncaaW/1VjlXne4xBVlIFtfbt3ZZjE51jDdKgM8guIVx83aZt1exvMhqQSHqjpQ==",
                     "requires": {
-                        "async": "2.6.3",
-                        "chalk": "2.4.2",
-                        "cli-table": "0.3.1",
-                        "cross-spawn": "6.0.5",
-                        "dargs": "6.1.0",
-                        "dateformat": "3.0.3",
-                        "debug": "4.1.1",
-                        "detect-conflict": "1.0.1",
-                        "error": "7.2.1",
-                        "find-up": "3.0.0",
-                        "github-username": "4.1.0",
-                        "istextorbinary": "2.6.0",
-                        "lodash": "4.17.13",
-                        "make-dir": "1.3.0",
-                        "mem-fs-editor": "5.1.0",
-                        "minimist": "1.2.0",
-                        "pretty-bytes": "5.3.0",
-                        "read-chunk": "3.2.0",
-                        "read-pkg-up": "4.0.0",
-                        "rimraf": "2.7.1",
-                        "run-async": "2.3.0",
-                        "shelljs": "0.8.3",
-                        "text-table": "0.2.0",
-                        "through2": "3.0.1",
-                        "yeoman-environment": "2.3.4"
+                        "async": "^2.6.2",
+                        "chalk": "^2.4.2",
+                        "cli-table": "^0.3.1",
+                        "cross-spawn": "^6.0.5",
+                        "dargs": "^6.1.0",
+                        "dateformat": "^3.0.3",
+                        "debug": "^4.1.1",
+                        "diff": "^4.0.1",
+                        "error": "^7.0.2",
+                        "find-up": "^3.0.0",
+                        "github-username": "^3.0.0",
+                        "istextorbinary": "^2.5.1",
+                        "lodash": "^4.17.11",
+                        "make-dir": "^3.0.0",
+                        "mem-fs-editor": "^6.0.0",
+                        "minimist": "^1.2.0",
+                        "pretty-bytes": "^5.2.0",
+                        "read-chunk": "^3.2.0",
+                        "read-pkg-up": "^5.0.0",
+                        "rimraf": "^2.6.3",
+                        "run-async": "^2.0.0",
+                        "shelljs": "^0.8.3",
+                        "text-table": "^0.2.0",
+                        "through2": "^3.0.1",
+                        "yeoman-environment": "^2.3.4"
                     },
                     "dependencies": {
                         "debug": {
@@ -2675,8 +2771,13 @@
                             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
                             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                             "requires": {
-                                "ms": "2.1.2"
+                                "ms": "^2.1.1"
                             }
+                        },
+                        "diff": {
+                            "version": "4.0.2",
+                            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+                            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
                         }
                     }
                 }
@@ -2709,7 +2810,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
             "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
             "requires": {
-                "pump": "3.0.0"
+                "pump": "^3.0.0"
             }
         },
         "get-value": {
@@ -2722,7 +2823,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "gh-got": {
@@ -2730,8 +2831,8 @@
             "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
             "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
             "requires": {
-                "got": "7.1.0",
-                "is-plain-obj": "1.1.0"
+                "got": "^7.0.0",
+                "is-plain-obj": "^1.1.0"
             }
         },
         "github-username": {
@@ -2739,7 +2840,7 @@
             "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
             "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
             "requires": {
-                "gh-got": "6.0.0"
+                "gh-got": "^6.0.0"
             }
         },
         "glob": {
@@ -2747,12 +2848,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.4",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-parent": {
@@ -2760,8 +2861,8 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -2769,7 +2870,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -2780,23 +2881,23 @@
             "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
         },
         "global-agent": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.7.tgz",
-            "integrity": "sha512-ooK7eqGYZku+LgnbfH/Iv0RJ74XfhrBZDlke1QSzcBt0bw1PmJcnRADPAQuFE+R45pKKDTynAr25SBasY2kvow==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
+            "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
             "requires": {
-                "boolean": "3.0.0",
-                "core-js": "3.6.2",
-                "es6-error": "4.1.1",
-                "matcher": "2.1.0",
-                "roarr": "2.14.6",
-                "semver": "6.3.0",
-                "serialize-error": "5.0.0"
+                "boolean": "^3.0.0",
+                "core-js": "^3.6.4",
+                "es6-error": "^4.1.1",
+                "matcher": "^2.1.0",
+                "roarr": "^2.15.2",
+                "semver": "^7.1.2",
+                "serialize-error": "^5.0.0"
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.2.tgz",
+                    "integrity": "sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ=="
                 }
             }
         },
@@ -2805,7 +2906,7 @@
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "global-tunnel-ng": {
@@ -2813,10 +2914,10 @@
             "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
             "integrity": "sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==",
             "requires": {
-                "encodeurl": "1.0.2",
-                "lodash": "4.17.13",
-                "npm-conf": "1.1.3",
-                "tunnel": "0.0.6"
+                "encodeurl": "^1.0.2",
+                "lodash": "^4.17.10",
+                "npm-conf": "^1.1.3",
+                "tunnel": "^0.0.6"
             }
         },
         "globals": {
@@ -2830,7 +2931,7 @@
             "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
             "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
             "requires": {
-                "define-properties": "1.1.3"
+                "define-properties": "^1.1.3"
             }
         },
         "globby": {
@@ -2838,13 +2939,13 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
             "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
             "requires": {
-                "array-union": "1.0.2",
+                "array-union": "^1.0.1",
                 "dir-glob": "2.0.0",
-                "fast-glob": "2.2.7",
-                "glob": "7.1.2",
-                "ignore": "3.3.10",
-                "pify": "3.0.0",
-                "slash": "1.0.0"
+                "fast-glob": "^2.0.2",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
             }
         },
         "got": {
@@ -2852,20 +2953,20 @@
             "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
             "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
             "requires": {
-                "decompress-response": "3.3.0",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-plain-obj": "1.1.0",
-                "is-retry-allowed": "1.2.0",
-                "is-stream": "1.1.0",
-                "isurl": "1.0.0",
-                "lowercase-keys": "1.0.1",
-                "p-cancelable": "0.3.0",
-                "p-timeout": "1.2.1",
-                "safe-buffer": "5.1.2",
-                "timed-out": "4.0.1",
-                "url-parse-lax": "1.0.0",
-                "url-to-options": "1.0.1"
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
             },
             "dependencies": {
                 "get-stream": {
@@ -2885,7 +2986,7 @@
             "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
             "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
             "requires": {
-                "lodash": "4.17.13"
+                "lodash": "^4.17.2"
             }
         },
         "growl": {
@@ -2899,9 +3000,9 @@
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "har-schema": {
@@ -2914,8 +3015,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "6.10.2",
-                "har-schema": "2.0.0"
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -2924,7 +3025,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -2932,7 +3033,7 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2963,7 +3064,7 @@
             "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
             "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
             "requires": {
-                "has-symbol-support-x": "1.4.2"
+                "has-symbol-support-x": "^1.4.1"
             }
         },
         "has-unicode": {
@@ -2976,9 +3077,9 @@
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -2986,8 +3087,8 @@
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-buffer": {
@@ -3000,7 +3101,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3021,10 +3122,10 @@
             "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
             "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
             "requires": {
-                "caseless": "0.12.0",
-                "concat-stream": "1.6.2",
-                "http-response-object": "3.0.2",
-                "parse-cache-control": "1.0.1"
+                "caseless": "^0.12.0",
+                "concat-stream": "^1.6.2",
+                "http-response-object": "^3.0.1",
+                "parse-cache-control": "^1.0.1"
             }
         },
         "http-cache-semantics": {
@@ -3037,7 +3138,7 @@
             "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
             "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
             "requires": {
-                "@types/node": "10.17.13"
+                "@types/node": "^10.0.3"
             }
         },
         "http-signature": {
@@ -3045,9 +3146,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.16.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "humanize-string": {
@@ -3055,7 +3156,7 @@
             "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-1.0.2.tgz",
             "integrity": "sha512-PH5GBkXqFxw5+4eKaKRIkD23y6vRd/IXSl7IldyJxEXpDH9SEIXRORkBtkGni/ae2P7RVOw6Wxypd2tGXhha1w==",
             "requires": {
-                "decamelize": "1.2.0"
+                "decamelize": "^1.0.0"
             }
         },
         "iconv-lite": {
@@ -3063,7 +3164,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ieee754": {
@@ -3096,8 +3197,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -3115,19 +3216,19 @@
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
             "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
             "requires": {
-                "ansi-escapes": "3.2.0",
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.2.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.13",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.1.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rxjs": "5.5.12",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rxjs": "^5.5.2",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             }
         },
         "insight": {
@@ -3135,15 +3236,15 @@
             "resolved": "https://registry.npmjs.org/insight/-/insight-0.10.1.tgz",
             "integrity": "sha512-kLGeYQkh18f8KuC68QKdi0iwUcIaayJVB/STpX7x452/7pAUm1yfG4giJwcxbrTh0zNYtc8kBR+6maLMOzglOQ==",
             "requires": {
-                "async": "2.6.3",
-                "chalk": "2.4.1",
-                "conf": "1.4.0",
-                "inquirer": "5.2.0",
-                "lodash.debounce": "4.0.8",
-                "os-name": "2.0.1",
-                "request": "2.88.0",
-                "tough-cookie": "2.5.0",
-                "uuid": "3.3.3"
+                "async": "^2.1.4",
+                "chalk": "^2.3.0",
+                "conf": "^1.3.1",
+                "inquirer": "^5.0.0",
+                "lodash.debounce": "^4.0.8",
+                "os-name": "^2.0.1",
+                "request": "^2.74.0",
+                "tough-cookie": "^2.0.0",
+                "uuid": "^3.0.0"
             },
             "dependencies": {
                 "conf": {
@@ -3151,11 +3252,11 @@
                     "resolved": "https://registry.npmjs.org/conf/-/conf-1.4.0.tgz",
                     "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
                     "requires": {
-                        "dot-prop": "4.2.0",
-                        "env-paths": "1.0.0",
-                        "make-dir": "1.3.0",
-                        "pkg-up": "2.0.0",
-                        "write-file-atomic": "2.4.3"
+                        "dot-prop": "^4.1.0",
+                        "env-paths": "^1.0.0",
+                        "make-dir": "^1.0.0",
+                        "pkg-up": "^2.0.0",
+                        "write-file-atomic": "^2.3.0"
                     }
                 }
             }
@@ -3170,8 +3271,8 @@
             "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
             "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
             "requires": {
-                "from2": "2.3.0",
-                "p-is-promise": "1.1.0"
+                "from2": "^2.1.1",
+                "p-is-promise": "^1.1.0"
             },
             "dependencies": {
                 "p-is-promise": {
@@ -3196,7 +3297,7 @@
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "is-buffer": {
@@ -3209,7 +3310,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3235,7 +3336,7 @@
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
             "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
             "requires": {
-                "ci-info": "1.6.0"
+                "ci-info": "^1.5.0"
             }
         },
         "is-data-descriptor": {
@@ -3243,7 +3344,7 @@
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "is-buffer": {
@@ -3256,7 +3357,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3272,9 +3373,9 @@
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3300,12 +3401,9 @@
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-finite": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-            "requires": {
-                "number-is-nan": "1.0.1"
-            }
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
         },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
@@ -3317,7 +3415,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-installed-globally": {
@@ -3325,8 +3423,8 @@
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-npm": {
@@ -3339,7 +3437,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "is-buffer": {
@@ -3352,7 +3450,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3372,7 +3470,7 @@
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -3385,7 +3483,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-promise": {
@@ -3404,7 +3502,7 @@
             "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
             "dev": true,
             "requires": {
-                "has": "1.0.3"
+                "has": "^1.0.3"
             }
         },
         "is-regexp": {
@@ -3433,7 +3531,7 @@
             "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
             "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
             "requires": {
-                "scoped-regex": "1.0.0"
+                "scoped-regex": "^1.0.0"
             }
         },
         "is-stream": {
@@ -3452,7 +3550,7 @@
             "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
             "dev": true,
             "requires": {
-                "has-symbols": "1.0.1"
+                "has-symbols": "^1.0.1"
             }
         },
         "is-typedarray": {
@@ -3485,7 +3583,7 @@
             "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
             "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
             "requires": {
-                "buffer-alloc": "1.2.0"
+                "buffer-alloc": "^1.2.0"
             }
         },
         "isexe": {
@@ -3508,9 +3606,9 @@
             "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
             "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
             "requires": {
-                "binaryextensions": "2.2.0",
-                "editions": "2.3.0",
-                "textextensions": "2.6.0"
+                "binaryextensions": "^2.1.2",
+                "editions": "^2.2.0",
+                "textextensions": "^2.5.0"
             }
         },
         "isurl": {
@@ -3518,8 +3616,8 @@
             "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
             "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
             "requires": {
-                "has-to-string-tag-x": "1.4.1",
-                "is-object": "1.0.1"
+                "has-to-string-tag-x": "^1.2.0",
+                "is-object": "^1.0.1"
             }
         },
         "jhipster-core": {
@@ -3551,12 +3649,12 @@
                     "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
                     "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
                     "requires": {
-                        "async": "1.0.0",
-                        "colors": "1.0.3",
-                        "cycle": "1.0.3",
-                        "eyes": "0.1.8",
-                        "isstream": "0.1.2",
-                        "stack-trace": "0.0.10"
+                        "async": "~1.0.0",
+                        "colors": "1.0.x",
+                        "cycle": "1.0.x",
+                        "eyes": "0.1.x",
+                        "isstream": "0.1.x",
+                        "stack-trace": "0.0.x"
                     }
                 }
             }
@@ -3582,8 +3680,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
             "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "js2xmlparser": {
@@ -3592,7 +3690,7 @@
             "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
             "dev": true,
             "requires": {
-                "xmlcreate": "1.0.2"
+                "xmlcreate": "^1.0.1"
             }
         },
         "jsbn": {
@@ -3607,17 +3705,17 @@
             "dev": true,
             "requires": {
                 "babylon": "7.0.0-beta.19",
-                "bluebird": "3.5.5",
-                "catharsis": "0.8.11",
-                "escape-string-regexp": "1.0.5",
-                "js2xmlparser": "3.0.0",
-                "klaw": "2.0.0",
-                "marked": "0.3.19",
-                "mkdirp": "0.5.1",
-                "requizzle": "0.2.3",
-                "strip-json-comments": "2.0.1",
+                "bluebird": "~3.5.0",
+                "catharsis": "~0.8.9",
+                "escape-string-regexp": "~1.0.5",
+                "js2xmlparser": "~3.0.0",
+                "klaw": "~2.0.0",
+                "marked": "~0.3.6",
+                "mkdirp": "~0.5.1",
+                "requizzle": "~0.2.1",
+                "strip-json-comments": "~2.0.1",
                 "taffydb": "2.6.2",
-                "underscore": "1.8.3"
+                "underscore": "~1.8.3"
             }
         },
         "json-buffer": {
@@ -3656,7 +3754,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.2.3"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsprim": {
@@ -3695,7 +3793,7 @@
             "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.2.3"
+                "graceful-fs": "^4.1.9"
             }
         },
         "kuler": {
@@ -3703,7 +3801,7 @@
             "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
             "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
             "requires": {
-                "colornames": "1.1.1"
+                "colornames": "^1.1.1"
             }
         },
         "latest-version": {
@@ -3711,7 +3809,7 @@
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
             },
             "dependencies": {
                 "get-stream": {
@@ -3724,17 +3822,17 @@
                     "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
                     "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                     "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.2.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.1",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                     }
                 },
                 "package-json": {
@@ -3742,10 +3840,10 @@
                     "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
                     "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                     "requires": {
-                        "got": "6.7.1",
-                        "registry-auth-token": "3.4.0",
-                        "registry-url": "3.1.0",
-                        "semver": "5.5.0"
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
                     }
                 }
             }
@@ -3755,7 +3853,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
             "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "requires": {
-                "invert-kv": "2.0.0"
+                "invert-kv": "^2.0.0"
             }
         },
         "levn": {
@@ -3764,19 +3862,24 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
+        },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
         },
         "load-json-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "requires": {
-                "graceful-fs": "4.2.3",
-                "parse-json": "4.0.0",
-                "pify": "3.0.0",
-                "strip-bom": "3.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
             }
         },
         "locate-path": {
@@ -3784,8 +3887,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "locutus": {
@@ -3793,7 +3896,7 @@
             "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
             "integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
             "requires": {
-                "es6-promise": "4.2.8"
+                "es6-promise": "^4.2.5"
             }
         },
         "lodash": {
@@ -3842,7 +3945,7 @@
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "^2.0.1"
             }
         },
         "logform": {
@@ -3850,11 +3953,11 @@
             "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
             "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
             "requires": {
-                "colors": "1.4.0",
-                "fast-safe-stringify": "2.0.7",
-                "fecha": "2.3.3",
-                "ms": "2.1.2",
-                "triple-beam": "1.3.0"
+                "colors": "^1.2.1",
+                "fast-safe-stringify": "^2.0.4",
+                "fecha": "^2.3.3",
+                "ms": "^2.1.1",
+                "triple-beam": "^1.3.0"
             },
             "dependencies": {
                 "ms": {
@@ -3875,8 +3978,8 @@
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lowercase-keys": {
@@ -3889,8 +3992,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
             "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "macos-release": {
@@ -3903,7 +4006,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "map-age-cleaner": {
@@ -3911,7 +4014,7 @@
             "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
             "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
             "requires": {
-                "p-defer": "1.0.0"
+                "p-defer": "^1.0.0"
             }
         },
         "map-cache": {
@@ -3929,7 +4032,7 @@
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "marked": {
@@ -3943,7 +4046,7 @@
             "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.1.0.tgz",
             "integrity": "sha512-o+nZr+vtJtgPNklyeUKkkH42OsK8WAfdgaJE2FNxcjLPg+5QbeEoT6vRj8Xq/iv18JlQ9cmKsEu0b94ixWf1YQ==",
             "requires": {
-                "escape-string-regexp": "2.0.0"
+                "escape-string-regexp": "^2.0.0"
             },
             "dependencies": {
                 "escape-string-regexp": {
@@ -3958,9 +4061,9 @@
             "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
             "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
             "requires": {
-                "map-age-cleaner": "0.1.3",
-                "mimic-fn": "2.1.0",
-                "p-is-promise": "2.1.0"
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^2.0.0",
+                "p-is-promise": "^2.0.0"
             },
             "dependencies": {
                 "mimic-fn": {
@@ -3975,29 +4078,39 @@
             "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
             "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "1.2.0",
-                "vinyl-file": "2.0.0"
+                "through2": "^2.0.0",
+                "vinyl": "^1.1.0",
+                "vinyl-file": "^2.0.0"
             }
         },
         "mem-fs-editor": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-5.1.0.tgz",
-            "integrity": "sha512-2Yt2GCYEbcotYbIJagmow4gEtHDqzpq5XN94+yAx/NT5+bGqIjkXnm3KCUQfE6kRfScGp9IZknScoGRKu8L78w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-6.0.0.tgz",
+            "integrity": "sha512-e0WfJAMm8Gv1mP5fEq/Blzy6Lt1VbLg7gNnZmZak7nhrBTibs+c6nQ4SKs/ZyJYHS1mFgDJeopsLAv7Ow0FMFg==",
             "requires": {
-                "commondir": "1.0.1",
-                "deep-extend": "0.6.0",
-                "ejs": "2.6.1",
-                "glob": "7.1.2",
-                "globby": "8.0.2",
-                "isbinaryfile": "3.0.3",
-                "mkdirp": "0.5.1",
-                "multimatch": "2.1.0",
-                "rimraf": "2.7.1",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0"
+                "commondir": "^1.0.1",
+                "deep-extend": "^0.6.0",
+                "ejs": "^2.6.1",
+                "glob": "^7.1.4",
+                "globby": "^9.2.0",
+                "isbinaryfile": "^4.0.0",
+                "mkdirp": "^0.5.0",
+                "multimatch": "^4.0.0",
+                "rimraf": "^2.6.3",
+                "through2": "^3.0.1",
+                "vinyl": "^2.2.0"
             },
             "dependencies": {
+                "array-differ": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+                    "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
+                },
+                "arrify": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+                },
                 "clone": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -4008,22 +4121,105 @@
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
                 },
+                "dir-glob": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+                    "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+                    "requires": {
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "globby": {
+                    "version": "9.2.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+                    "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "array-union": "^1.0.2",
+                        "dir-glob": "^2.2.2",
+                        "fast-glob": "^2.2.6",
+                        "glob": "^7.1.3",
+                        "ignore": "^4.0.3",
+                        "pify": "^4.0.1",
+                        "slash": "^2.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+                },
+                "isbinaryfile": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.4.tgz",
+                    "integrity": "sha512-pEutbN134CzcjlLS1myKX/uxNjwU5eBVSprvkpv3+3dqhBHUZLIWJQowC40w5c0Zf19vBY8mrZl88y5J4RAPbQ=="
+                },
+                "multimatch": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+                    "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+                    "requires": {
+                        "@types/minimatch": "^3.0.3",
+                        "array-differ": "^3.0.0",
+                        "array-union": "^2.1.0",
+                        "arrify": "^2.0.1",
+                        "minimatch": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "array-union": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+                            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+                        }
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+                },
                 "replace-ext": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
                     "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+                },
+                "through2": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+                    "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+                    "requires": {
+                        "readable-stream": "2 || 3"
+                    }
                 },
                 "vinyl": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.3",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -4033,15 +4229,15 @@
             "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
             "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
             "requires": {
-                "camelcase-keys": "4.2.0",
-                "decamelize-keys": "1.1.0",
-                "loud-rejection": "1.6.0",
-                "minimist-options": "3.0.2",
-                "normalize-package-data": "2.5.0",
-                "read-pkg-up": "3.0.0",
-                "redent": "2.0.0",
-                "trim-newlines": "2.0.0",
-                "yargs-parser": "10.1.0"
+                "camelcase-keys": "^4.0.0",
+                "decamelize-keys": "^1.0.0",
+                "loud-rejection": "^1.0.0",
+                "minimist-options": "^3.0.1",
+                "normalize-package-data": "^2.3.4",
+                "read-pkg-up": "^3.0.0",
+                "redent": "^2.0.0",
+                "trim-newlines": "^2.0.0",
+                "yargs-parser": "^10.0.0"
             }
         },
         "merge2": {
@@ -4054,19 +4250,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.13",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4079,8 +4275,8 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -4088,7 +4284,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 },
                 "kind-of": {
@@ -4126,7 +4322,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -4139,8 +4335,8 @@
             "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
             "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
             "requires": {
-                "arrify": "1.0.1",
-                "is-plain-obj": "1.1.0"
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0"
             }
         },
         "mixin-deep": {
@@ -4148,8 +4344,8 @@
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
             "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -4157,7 +4353,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -4201,7 +4397,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -4216,10 +4412,10 @@
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "mute-stream": {
@@ -4232,17 +4428,17 @@
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4255,8 +4451,8 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -4264,7 +4460,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 },
                 "kind-of": {
@@ -4291,11 +4487,11 @@
             "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
             "dev": true,
             "requires": {
-                "@sinonjs/formatio": "3.2.2",
-                "@sinonjs/text-encoding": "0.7.1",
-                "just-extend": "4.0.2",
-                "lolex": "5.1.2",
-                "path-to-regexp": "1.8.0"
+                "@sinonjs/formatio": "^3.2.1",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "lolex": "^5.0.1",
+                "path-to-regexp": "^1.7.0"
             },
             "dependencies": {
                 "@sinonjs/formatio": {
@@ -4304,8 +4500,8 @@
                     "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
                     "dev": true,
                     "requires": {
-                        "@sinonjs/commons": "1.7.0",
-                        "@sinonjs/samsam": "3.3.3"
+                        "@sinonjs/commons": "^1",
+                        "@sinonjs/samsam": "^3.1.0"
                     }
                 },
                 "lolex": {
@@ -4314,7 +4510,7 @@
                     "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
                     "dev": true,
                     "requires": {
-                        "@sinonjs/commons": "1.7.0"
+                        "@sinonjs/commons": "^1.7.0"
                     }
                 }
             }
@@ -4324,10 +4520,10 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "requires": {
-                "hosted-git-info": "2.8.5",
-                "resolve": "1.14.2",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.4"
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-url": {
@@ -4335,9 +4531,9 @@
             "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
             "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
             "requires": {
-                "prepend-http": "2.0.0",
-                "query-string": "5.1.1",
-                "sort-keys": "2.0.0"
+                "prepend-http": "^2.0.0",
+                "query-string": "^5.0.1",
+                "sort-keys": "^2.0.0"
             },
             "dependencies": {
                 "prepend-http": {
@@ -4352,8 +4548,8 @@
             "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
             "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
             "requires": {
-                "config-chain": "1.1.12",
-                "pify": "3.0.0"
+                "config-chain": "^1.1.11",
+                "pify": "^3.0.0"
             }
         },
         "npm-keyword": {
@@ -4361,8 +4557,8 @@
             "resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-5.0.0.tgz",
             "integrity": "sha1-mbha7Cn8s4jS3TUfABO/Umh4fmc=",
             "requires": {
-                "got": "7.1.0",
-                "registry-url": "3.1.0"
+                "got": "^7.1.0",
+                "registry-url": "^3.0.3"
             }
         },
         "npm-run-path": {
@@ -4370,7 +4566,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "npmlog": {
@@ -4378,9 +4574,9 @@
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
             "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
             "requires": {
-                "ansi": "0.3.1",
-                "are-we-there-yet": "1.1.5",
-                "gauge": "1.2.7"
+                "ansi": "~0.3.1",
+                "are-we-there-yet": "~1.1.2",
+                "gauge": "~1.2.5"
             }
         },
         "number-is-nan": {
@@ -4403,9 +4599,9 @@
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -4413,7 +4609,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-buffer": {
@@ -4426,7 +4622,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4447,7 +4643,7 @@
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.assign": {
@@ -4456,10 +4652,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.1",
-                "object-keys": "1.1.1"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.entries": {
@@ -4468,10 +4664,10 @@
             "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.0",
-                "function-bind": "1.1.1",
-                "has": "1.0.3"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
             }
         },
         "object.pick": {
@@ -4479,7 +4675,7 @@
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "once": {
@@ -4487,7 +4683,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "one-time": {
@@ -4500,7 +4696,7 @@
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "open": {
@@ -4508,7 +4704,7 @@
             "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
             "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
             "requires": {
-                "is-wsl": "1.1.0"
+                "is-wsl": "^1.1.0"
             }
         },
         "optionator": {
@@ -4517,12 +4713,12 @@
             "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "word-wrap": "1.2.3"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
             }
         },
         "ora": {
@@ -4530,12 +4726,12 @@
             "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
             "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
             "requires": {
-                "chalk": "2.4.2",
-                "cli-cursor": "2.1.0",
-                "cli-spinners": "2.2.0",
-                "log-symbols": "2.2.0",
-                "strip-ansi": "5.2.0",
-                "wcwidth": "1.0.1"
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-spinners": "^2.0.0",
+                "log-symbols": "^2.2.0",
+                "strip-ansi": "^5.2.0",
+                "wcwidth": "^1.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -4548,9 +4744,9 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "strip-ansi": {
@@ -4558,7 +4754,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "requires": {
-                        "ansi-regex": "4.1.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -4573,9 +4769,9 @@
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
             "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
             "requires": {
-                "execa": "1.0.0",
-                "lcid": "2.0.0",
-                "mem": "4.3.0"
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
             }
         },
         "os-name": {
@@ -4583,8 +4779,8 @@
             "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
             "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
             "requires": {
-                "macos-release": "1.1.0",
-                "win-release": "1.1.1"
+                "macos-release": "^1.0.0",
+                "win-release": "^1.0.0"
             }
         },
         "os-shim": {
@@ -4598,11 +4794,25 @@
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "p-any": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-any/-/p-any-1.1.0.tgz",
-            "integrity": "sha512-Ef0tVa4CZ5pTAmKn+Cg3w8ABBXh+hHO1aV8281dKOoUHfX+3tjG2EaFcC+aZyagg9b4EYGsHEjz21DnEE8Og2g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-any/-/p-any-2.1.0.tgz",
+            "integrity": "sha512-JAERcaMBLYKMq+voYw36+x5Dgh47+/o7yuv2oQYuSSUml4YeqJEFznBrY2UeEkoSHqBua6hz518n/PsowTYLLg==",
             "requires": {
-                "p-some": "2.0.1"
+                "p-cancelable": "^2.0.0",
+                "p-some": "^4.0.0",
+                "type-fest": "^0.3.0"
+            },
+            "dependencies": {
+                "p-cancelable": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+                    "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
+                },
+                "type-fest": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+                    "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+                }
             }
         },
         "p-cancelable": {
@@ -4630,7 +4840,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -4638,15 +4848,23 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "requires": {
-                "p-limit": "1.3.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-some": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/p-some/-/p-some-2.0.1.tgz",
-            "integrity": "sha1-Zdh8ixVO289SIdFnd4ttLhUPbwY=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-some/-/p-some-4.1.0.tgz",
+            "integrity": "sha512-MF/HIbq6GeBqTrTIl5OJubzkGU+qfFhAFi0gnTAK6rgEIJIknEiABHOTtQu4e6JiXjIwuMPMUFQzyHh5QjCl1g==",
             "requires": {
-                "aggregate-error": "1.0.0"
+                "aggregate-error": "^3.0.0",
+                "p-cancelable": "^2.0.0"
+            },
+            "dependencies": {
+                "p-cancelable": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+                    "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
+                }
             }
         },
         "p-timeout": {
@@ -4654,7 +4872,7 @@
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
             "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
             "requires": {
-                "p-finally": "1.0.0"
+                "p-finally": "^1.0.0"
             }
         },
         "p-try": {
@@ -4667,10 +4885,10 @@
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-5.0.0.tgz",
             "integrity": "sha512-EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==",
             "requires": {
-                "got": "8.3.2",
-                "registry-auth-token": "3.4.0",
-                "registry-url": "3.1.0",
-                "semver": "5.5.0"
+                "got": "^8.3.1",
+                "registry-auth-token": "^3.3.2",
+                "registry-url": "^3.1.0",
+                "semver": "^5.5.0"
             },
             "dependencies": {
                 "get-stream": {
@@ -4683,23 +4901,23 @@
                     "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
                     "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
                     "requires": {
-                        "@sindresorhus/is": "0.7.0",
-                        "cacheable-request": "2.1.4",
-                        "decompress-response": "3.3.0",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "into-stream": "3.1.0",
-                        "is-retry-allowed": "1.2.0",
-                        "isurl": "1.0.0",
-                        "lowercase-keys": "1.0.1",
-                        "mimic-response": "1.0.1",
-                        "p-cancelable": "0.4.1",
-                        "p-timeout": "2.0.1",
-                        "pify": "3.0.0",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "url-parse-lax": "3.0.0",
-                        "url-to-options": "1.0.1"
+                        "@sindresorhus/is": "^0.7.0",
+                        "cacheable-request": "^2.1.1",
+                        "decompress-response": "^3.3.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "into-stream": "^3.1.0",
+                        "is-retry-allowed": "^1.1.0",
+                        "isurl": "^1.0.0-alpha5",
+                        "lowercase-keys": "^1.0.0",
+                        "mimic-response": "^1.0.0",
+                        "p-cancelable": "^0.4.0",
+                        "p-timeout": "^2.0.1",
+                        "pify": "^3.0.0",
+                        "safe-buffer": "^5.1.1",
+                        "timed-out": "^4.0.1",
+                        "url-parse-lax": "^3.0.0",
+                        "url-to-options": "^1.0.1"
                     }
                 },
                 "p-cancelable": {
@@ -4712,7 +4930,7 @@
                     "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
                     "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
                     "requires": {
-                        "p-finally": "1.0.0"
+                        "p-finally": "^1.0.0"
                     }
                 },
                 "prepend-http": {
@@ -4725,7 +4943,7 @@
                     "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
                     "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
                     "requires": {
-                        "prepend-http": "2.0.0"
+                        "prepend-http": "^2.0.0"
                     }
                 }
             }
@@ -4750,7 +4968,7 @@
             "resolved": "https://registry.npmjs.org/parse-help/-/parse-help-1.0.0.tgz",
             "integrity": "sha512-dlOrbBba6Rrw/nrJ+V7/vkGZdiimWJQzMHZZrYsUq03JE8AV3fAv6kOYX7dP/w2h67lIdmRf8ES8mU44xAgE/Q==",
             "requires": {
-                "execall": "1.0.0"
+                "execall": "^1.0.0"
             }
         },
         "parse-json": {
@@ -4758,8 +4976,8 @@
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "requires": {
-                "error-ex": "1.3.2",
-                "json-parse-better-errors": "1.0.2"
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
             }
         },
         "pascalcase": {
@@ -4768,45 +4986,11 @@
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
         "passwd-user": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/passwd-user/-/passwd-user-2.1.0.tgz",
-            "integrity": "sha1-+tnbauJS+LCI4MXezSCn2gxdnx4=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/passwd-user/-/passwd-user-3.0.0.tgz",
+            "integrity": "sha512-Iu90rROks+uDK00ppSewoZyqeCwjGR6W8PcY0Phl8YFWju/lRmIogQb98+vSb5RUeYkONL3IC4ZLBFg4FiE0Hg==",
             "requires": {
-                "execa": "0.4.0",
-                "pify": "2.3.0"
-            },
-            "dependencies": {
-                "execa": {
-                    "version": "0.4.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-                    "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-                    "requires": {
-                        "cross-spawn-async": "2.2.5",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "1.0.0",
-                        "object-assign": "4.1.1",
-                        "path-key": "1.0.0",
-                        "strip-eof": "1.0.0"
-                    }
-                },
-                "npm-run-path": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-                    "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-                    "requires": {
-                        "path-key": "1.0.0"
-                    }
-                },
-                "path-key": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-                    "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-                }
+                "execa": "^1.0.0"
             }
         },
         "path-dirname": {
@@ -4861,7 +5045,7 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "pathval": {
@@ -4890,7 +5074,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -4899,7 +5083,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "pkg-up": {
@@ -4907,7 +5091,7 @@
             "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
             "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "plugin-error": {
@@ -4915,11 +5099,11 @@
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
         },
         "pluralize": {
@@ -4938,9 +5122,9 @@
             "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
             "dev": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "spawn-sync": "1.0.15",
-                "which": "1.2.14"
+                "cross-spawn": "^5.0.1",
+                "spawn-sync": "^1.0.15",
+                "which": "1.2.x"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -4949,9 +5133,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.5",
-                        "shebang-command": "1.2.0",
-                        "which": "1.2.14"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "which": {
@@ -4960,7 +5144,7 @@
                     "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -4988,7 +5172,7 @@
             "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
             "dev": true,
             "requires": {
-                "fast-diff": "1.2.0"
+                "fast-diff": "^1.1.2"
             }
         },
         "pretty-bytes": {
@@ -5011,7 +5195,7 @@
             "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
             "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.6"
             }
         },
         "proto-list": {
@@ -5034,8 +5218,8 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "requires": {
-                "end-of-stream": "1.4.4",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "punycode": {
@@ -5053,9 +5237,9 @@
             "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
             "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
             "requires": {
-                "decode-uri-component": "0.2.0",
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
             }
         },
         "querystring": {
@@ -5073,8 +5257,8 @@
             "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.9.tgz",
             "integrity": "sha512-maAX1cnBkzIZ89O4tSQUOF098xjGMC8N+9vuY/WfHwg87THw6odD2Br35donlj5e6KnB1SB0QBHhTQhhDHuTPQ==",
             "requires": {
-                "drange": "1.1.1",
-                "ret": "0.2.2"
+                "drange": "^1.0.0",
+                "ret": "^0.2.0"
             }
         },
         "rc": {
@@ -5082,10 +5266,10 @@
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             },
             "dependencies": {
                 "minimist": {
@@ -5100,8 +5284,8 @@
             "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
             "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
             "requires": {
-                "pify": "4.0.1",
-                "with-open-file": "0.1.7"
+                "pify": "^4.0.1",
+                "with-open-file": "^0.1.6"
             },
             "dependencies": {
                 "pify": {
@@ -5122,9 +5306,9 @@
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "requires": {
-                "load-json-file": "4.0.0",
-                "normalize-package-data": "2.5.0",
-                "path-type": "3.0.0"
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
             }
         },
         "read-pkg-up": {
@@ -5132,8 +5316,8 @@
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
             "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
             "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "3.0.0"
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
             }
         },
         "readable-stream": {
@@ -5141,13 +5325,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.1",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "rechoir": {
@@ -5155,7 +5339,7 @@
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "requires": {
-                "resolve": "1.14.2"
+                "resolve": "^1.1.6"
             }
         },
         "redent": {
@@ -5163,8 +5347,8 @@
             "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
             "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
             "requires": {
-                "indent-string": "3.2.0",
-                "strip-indent": "2.0.0"
+                "indent-string": "^3.0.0",
+                "strip-indent": "^2.0.0"
             }
         },
         "regenerator-runtime": {
@@ -5177,8 +5361,8 @@
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5186,8 +5370,8 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -5195,7 +5379,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5211,8 +5395,8 @@
             "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.0"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
             }
         },
         "regexpp": {
@@ -5226,8 +5410,8 @@
             "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
             "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
             "requires": {
-                "rc": "1.2.8",
-                "safe-buffer": "5.1.2"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -5235,7 +5419,7 @@
             "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "requires": {
-                "rc": "1.2.8"
+                "rc": "^1.0.1"
             }
         },
         "remove-trailing-separator": {
@@ -5258,7 +5442,7 @@
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace-ext": {
@@ -5271,26 +5455,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.9.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.8",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.3",
-                "har-validator": "5.1.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.26",
-                "oauth-sign": "0.9.0",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.4.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.3"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             },
             "dependencies": {
                 "punycode": {
@@ -5303,8 +5487,8 @@
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "requires": {
-                        "psl": "1.7.0",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 }
             }
@@ -5327,8 +5511,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "requizzle": {
@@ -5337,7 +5521,7 @@
             "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.15"
+                "lodash": "^4.17.14"
             },
             "dependencies": {
                 "lodash": {
@@ -5353,7 +5537,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
             "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.6"
             }
         },
         "resolve-from": {
@@ -5372,7 +5556,7 @@
             "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
             "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
             "requires": {
-                "lowercase-keys": "1.0.1"
+                "lowercase-keys": "^1.0.0"
             }
         },
         "restore-cursor": {
@@ -5380,8 +5564,8 @@
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "ret": {
@@ -5400,7 +5584,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "requires": {
-                "glob": "7.1.6"
+                "glob": "^7.1.3"
             },
             "dependencies": {
                 "glob": {
@@ -5408,27 +5592,27 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
                     "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.4",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
         },
         "roarr": {
-            "version": "2.14.6",
-            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.14.6.tgz",
-            "integrity": "sha512-qjbw0BEesKA+3XFBPt+KVe1PC/Z6ShfJ4wPlx2XifqH5h2Lj8/KQT5XJTsy3n1Es5kai+BwKALaECW3F70B1cg==",
+            "version": "2.15.2",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
+            "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
             "requires": {
-                "boolean": "3.0.0",
-                "detect-node": "2.0.4",
-                "globalthis": "1.0.1",
-                "json-stringify-safe": "5.0.1",
-                "semver-compare": "1.0.0",
-                "sprintf-js": "1.1.2"
+                "boolean": "^3.0.0",
+                "detect-node": "^2.0.4",
+                "globalthis": "^1.0.1",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0",
+                "sprintf-js": "^1.1.2"
             },
             "dependencies": {
                 "sprintf-js": {
@@ -5443,8 +5627,8 @@
             "resolved": "https://registry.npmjs.org/root-check/-/root-check-1.0.0.tgz",
             "integrity": "sha1-xSp5S/Dbn61WdTbkGJjwyeCoZpc=",
             "requires": {
-                "downgrade-root": "1.2.2",
-                "sudo-block": "1.2.0"
+                "downgrade-root": "^1.0.0",
+                "sudo-block": "^1.1.0"
             }
         },
         "run-async": {
@@ -5452,7 +5636,7 @@
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "rx": {
@@ -5478,7 +5662,7 @@
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             },
             "dependencies": {
                 "ret": {
@@ -5524,7 +5708,7 @@
             "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.3"
             }
         },
         "semver-regex": {
@@ -5537,7 +5721,7 @@
             "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
             "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.3.0"
             }
         },
         "serialize-error": {
@@ -5545,7 +5729,14 @@
             "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
             "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
             "requires": {
-                "type-fest": "0.8.1"
+                "type-fest": "^0.8.0"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+                }
             }
         },
         "set-blocking": {
@@ -5559,10 +5750,10 @@
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
             "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5570,7 +5761,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -5580,7 +5771,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -5593,9 +5784,9 @@
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
             "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
             "requires": {
-                "glob": "7.1.2",
-                "interpret": "1.2.0",
-                "rechoir": "0.6.2"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
             }
         },
         "signal-exit": {
@@ -5608,7 +5799,7 @@
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
             "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
             "requires": {
-                "is-arrayish": "0.3.2"
+                "is-arrayish": "^0.3.1"
             }
         },
         "sinon": {
@@ -5617,13 +5808,13 @@
             "integrity": "sha512-MatciKXyM5pXMSoqd593MqTsItJNCkSSl53HJYeKR5wfsDdp2yljjUQJLfVwAWLoBNfx1HThteqygGQ0ZEpXpQ==",
             "dev": true,
             "requires": {
-                "@sinonjs/formatio": "2.0.0",
-                "diff": "3.5.0",
-                "lodash.get": "4.4.2",
-                "lolex": "2.7.5",
-                "nise": "1.5.3",
-                "supports-color": "5.5.0",
-                "type-detect": "4.0.8"
+                "@sinonjs/formatio": "^2.0.0",
+                "diff": "^3.5.0",
+                "lodash.get": "^4.4.2",
+                "lolex": "^2.4.2",
+                "nise": "^1.3.3",
+                "supports-color": "^5.4.0",
+                "type-detect": "^4.0.8"
             }
         },
         "slash": {
@@ -5637,7 +5828,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "snapdragon": {
@@ -5645,14 +5836,14 @@
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.3",
-                "use": "3.1.1"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -5668,7 +5859,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -5676,7 +5867,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -5686,9 +5877,9 @@
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -5696,7 +5887,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -5704,7 +5895,7 @@
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -5712,7 +5903,7 @@
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -5720,9 +5911,9 @@
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "kind-of": {
@@ -5737,7 +5928,7 @@
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "is-buffer": {
@@ -5750,7 +5941,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5760,7 +5951,7 @@
             "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
             "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.0.0"
             }
         },
         "sort-on": {
@@ -5768,8 +5959,8 @@
             "resolved": "https://registry.npmjs.org/sort-on/-/sort-on-3.0.0.tgz",
             "integrity": "sha512-e2RHeY1iM6dT9od3RoqeJSyz3O7naNFsGy34+EFEcwghjAncuOXC2/Xwq87S4FbypqLVp6PcizYEsGEGsGIDXA==",
             "requires": {
-                "arrify": "1.0.1",
-                "dot-prop": "4.2.0"
+                "arrify": "^1.0.0",
+                "dot-prop": "^4.1.1"
             }
         },
         "source-map": {
@@ -5782,11 +5973,11 @@
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
             "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
             "requires": {
-                "atob": "2.1.2",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-url": {
@@ -5799,8 +5990,8 @@
             "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
             "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
             "requires": {
-                "concat-stream": "1.6.2",
-                "os-shim": "0.1.3"
+                "concat-stream": "^1.4.7",
+                "os-shim": "^0.1.2"
             }
         },
         "spdx-correct": {
@@ -5808,8 +5999,8 @@
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.5"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -5822,8 +6013,8 @@
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "requires": {
-                "spdx-exceptions": "2.2.0",
-                "spdx-license-ids": "3.0.5"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -5836,7 +6027,7 @@
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5844,8 +6035,8 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -5853,7 +6044,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5868,15 +6059,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stack-trace": {
@@ -5889,8 +6080,8 @@
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -5898,7 +6089,7 @@
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -5908,7 +6099,7 @@
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "requires": {
-                "readable-stream": "2.3.7"
+                "readable-stream": "^2.0.2"
             }
         },
         "strict-uri-encode": {
@@ -5916,21 +6107,13 @@
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
             "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "requires": {
-                "safe-buffer": "5.1.2"
-            }
-        },
         "string-length": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
             "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
             "requires": {
-                "astral-regex": "1.0.0",
-                "strip-ansi": "4.0.0"
+                "astral-regex": "^1.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string-template": {
@@ -5943,8 +6126,8 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string.prototype.matchall": {
@@ -5953,11 +6136,11 @@
             "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.0",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.1",
-                "regexp.prototype.flags": "1.3.0"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.10.0",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "regexp.prototype.flags": "^1.2.0"
             }
         },
         "string.prototype.trimleft": {
@@ -5966,8 +6149,8 @@
             "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "function-bind": "1.1.1"
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
             }
         },
         "string.prototype.trimright": {
@@ -5976,8 +6159,16 @@
             "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "function-bind": "1.1.1"
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "requires": {
+                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -5985,7 +6176,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
             }
         },
         "strip-bom": {
@@ -5998,8 +6189,8 @@
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
             "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
             "requires": {
-                "first-chunk-stream": "2.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -6007,7 +6198,7 @@
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -6032,9 +6223,9 @@
             "resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz",
             "integrity": "sha1-zFOb+BkWJNT1B9g+60W0zqJ/NGM=",
             "requires": {
-                "chalk": "1.1.3",
-                "is-docker": "1.1.0",
-                "is-root": "1.0.0"
+                "chalk": "^1.0.0",
+                "is-docker": "^1.0.0",
+                "is-root": "^1.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -6052,11 +6243,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -6064,7 +6255,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -6079,7 +6270,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "symbol-observable": {
@@ -6092,9 +6283,9 @@
             "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.0.0.tgz",
             "integrity": "sha512-jGNIAlCi9iU4X3Dm4oQnNQshDD3h0/1A7r79LyqjbjUnj69sX6mShAXlhRXgImsfVKtTcnra1jfzabdZvp+Lmw==",
             "requires": {
-                "http-response-object": "3.0.2",
-                "sync-rpc": "1.3.6",
-                "then-request": "6.0.2"
+                "http-response-object": "^3.0.1",
+                "sync-rpc": "^1.2.1",
+                "then-request": "^6.0.0"
             }
         },
         "sync-rpc": {
@@ -6102,7 +6293,7 @@
             "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
             "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
             "requires": {
-                "get-port": "3.2.0"
+                "get-port": "^3.1.0"
             }
         },
         "syntax-error": {
@@ -6111,7 +6302,7 @@
             "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
             "dev": true,
             "requires": {
-                "acorn-node": "1.8.2"
+                "acorn-node": "^1.2.0"
             }
         },
         "table": {
@@ -6120,12 +6311,12 @@
             "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
             "dev": true,
             "requires": {
-                "ajv": "6.10.2",
-                "ajv-keywords": "3.4.1",
-                "chalk": "2.4.1",
-                "lodash": "4.17.13",
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
         },
         "tabtab": {
@@ -6133,14 +6324,14 @@
             "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-2.2.2.tgz",
             "integrity": "sha1-egR/FDsBC0y9MfhX6ClhUSy/ThQ=",
             "requires": {
-                "debug": "2.6.9",
-                "inquirer": "1.2.3",
-                "lodash.difference": "4.5.0",
-                "lodash.uniq": "4.5.0",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "npmlog": "2.0.4",
-                "object-assign": "4.1.1"
+                "debug": "^2.2.0",
+                "inquirer": "^1.0.2",
+                "lodash.difference": "^4.5.0",
+                "lodash.uniq": "^4.5.0",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "npmlog": "^2.0.3",
+                "object-assign": "^4.1.0"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -6163,11 +6354,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "cli-cursor": {
@@ -6175,7 +6366,7 @@
                     "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
                     "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
                     "requires": {
-                        "restore-cursor": "1.0.1"
+                        "restore-cursor": "^1.0.1"
                     }
                 },
                 "debug": {
@@ -6191,9 +6382,9 @@
                     "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
                     "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
                     "requires": {
-                        "extend": "3.0.2",
-                        "spawn-sync": "1.0.15",
-                        "tmp": "0.0.29"
+                        "extend": "^3.0.0",
+                        "spawn-sync": "^1.0.15",
+                        "tmp": "^0.0.29"
                     }
                 },
                 "figures": {
@@ -6201,8 +6392,8 @@
                     "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
                     "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
                     "requires": {
-                        "escape-string-regexp": "1.0.5",
-                        "object-assign": "4.1.1"
+                        "escape-string-regexp": "^1.0.5",
+                        "object-assign": "^4.1.0"
                     }
                 },
                 "inquirer": {
@@ -6210,20 +6401,20 @@
                     "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
                     "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
                     "requires": {
-                        "ansi-escapes": "1.4.0",
-                        "chalk": "1.1.3",
-                        "cli-cursor": "1.0.2",
-                        "cli-width": "2.2.0",
-                        "external-editor": "1.1.1",
-                        "figures": "1.7.0",
-                        "lodash": "4.17.13",
+                        "ansi-escapes": "^1.1.0",
+                        "chalk": "^1.0.0",
+                        "cli-cursor": "^1.0.1",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^1.1.0",
+                        "figures": "^1.3.5",
+                        "lodash": "^4.3.0",
                         "mute-stream": "0.0.6",
-                        "pinkie-promise": "2.0.1",
-                        "run-async": "2.3.0",
-                        "rx": "4.1.0",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "through": "2.3.8"
+                        "pinkie-promise": "^2.0.0",
+                        "run-async": "^2.2.0",
+                        "rx": "^4.1.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.0",
+                        "through": "^2.3.6"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -6231,7 +6422,7 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "minimist": {
@@ -6254,8 +6445,8 @@
                     "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                     "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
                     "requires": {
-                        "exit-hook": "1.1.1",
-                        "onetime": "1.1.0"
+                        "exit-hook": "^1.0.0",
+                        "onetime": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -6263,9 +6454,9 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -6273,7 +6464,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -6286,7 +6477,7 @@
                     "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
                     "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
                     "requires": {
-                        "os-tmpdir": "1.0.2"
+                        "os-tmpdir": "~1.0.1"
                     }
                 }
             }
@@ -6302,8 +6493,8 @@
             "resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
             "integrity": "sha1-tNTw3u0gauffd1sSnqLKbeUvJt0=",
             "requires": {
-                "get-stdin": "4.0.1",
-                "minimist": "1.2.0"
+                "get-stdin": "^4.0.1",
+                "minimist": "^1.1.0"
             },
             "dependencies": {
                 "minimist": {
@@ -6318,7 +6509,7 @@
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -6326,9 +6517,9 @@
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "requires": {
-                        "lru-cache": "4.1.5",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "execa": {
@@ -6336,13 +6527,13 @@
                     "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 },
                 "get-stream": {
@@ -6372,17 +6563,17 @@
             "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
             "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
             "requires": {
-                "@types/concat-stream": "1.6.0",
+                "@types/concat-stream": "^1.6.0",
                 "@types/form-data": "0.0.33",
-                "@types/node": "8.10.59",
-                "@types/qs": "6.9.0",
-                "caseless": "0.12.0",
-                "concat-stream": "1.6.2",
-                "form-data": "2.3.3",
-                "http-basic": "8.1.3",
-                "http-response-object": "3.0.2",
-                "promise": "8.0.3",
-                "qs": "6.5.2"
+                "@types/node": "^8.0.0",
+                "@types/qs": "^6.2.31",
+                "caseless": "~0.12.0",
+                "concat-stream": "^1.6.0",
+                "form-data": "^2.2.0",
+                "http-basic": "^8.1.1",
+                "http-response-object": "^3.0.1",
+                "promise": "^8.0.0",
+                "qs": "^6.4.0"
             },
             "dependencies": {
                 "@types/node": {
@@ -6402,8 +6593,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
-                "readable-stream": "2.3.7",
-                "xtend": "4.0.2"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "timed-out": {
@@ -6421,7 +6612,7 @@
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "to-object-path": {
@@ -6429,7 +6620,7 @@
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "is-buffer": {
@@ -6442,7 +6633,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6452,10 +6643,10 @@
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6463,8 +6654,8 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -6472,7 +6663,7 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -6482,8 +6673,8 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "tough-cookie": {
@@ -6491,8 +6682,8 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "requires": {
-                "psl": "1.7.0",
-                "punycode": "2.1.1"
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             },
             "dependencies": {
                 "punycode": {
@@ -6527,7 +6718,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -6540,10 +6731,10 @@
             "resolved": "https://registry.npmjs.org/twig/-/twig-1.14.0.tgz",
             "integrity": "sha512-ut1LslUKAeF56TYQglabJaATUqbNuGO3EcXDhUspAdNbxez5VwTk2n8H00V0VfNy9Scet+VGQP8oPxt4v6mykQ==",
             "requires": {
-                "@babel/runtime": "7.7.7",
-                "locutus": "2.0.11",
-                "minimatch": "3.0.4",
-                "walk": "2.3.14"
+                "@babel/runtime": "^7.6.3",
+                "locutus": "^2.0.5",
+                "minimatch": "3.0.x",
+                "walk": "2.3.x"
             }
         },
         "type-check": {
@@ -6552,7 +6743,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-detect": {
@@ -6562,9 +6753,9 @@
             "dev": true
         },
         "type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
         },
         "typedarray": {
             "version": "0.0.6",
@@ -6582,10 +6773,10 @@
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
             "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "2.0.1"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^2.0.1"
             },
             "dependencies": {
                 "arr-union": {
@@ -6600,7 +6791,7 @@
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "requires": {
-                "crypto-random-string": "1.0.0"
+                "crypto-random-string": "^1.0.0"
             }
         },
         "universalify": {
@@ -6613,8 +6804,8 @@
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -6622,9 +6813,9 @@
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -6659,16 +6850,16 @@
             "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
             "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
             "requires": {
-                "boxen": "1.3.0",
-                "chalk": "2.4.1",
-                "configstore": "3.1.2",
-                "import-lazy": "2.1.0",
-                "is-ci": "1.2.1",
-                "is-installed-globally": "0.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "uri-js": {
@@ -6676,7 +6867,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -6705,7 +6896,7 @@
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
             }
         },
         "url-to-options": {
@@ -6723,7 +6914,7 @@
             "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
             "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "util-deprecate": {
@@ -6741,8 +6932,8 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "requires": {
-                "spdx-correct": "3.1.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "verror": {
@@ -6750,9 +6941,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
@@ -6760,8 +6951,8 @@
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
             "requires": {
-                "clone": "1.0.4",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -6770,12 +6961,12 @@
             "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
             "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
             "requires": {
-                "graceful-fs": "4.2.3",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "2.0.0",
-                "vinyl": "1.2.0"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.3.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^2.0.0",
+                "vinyl": "^1.1.0"
             },
             "dependencies": {
                 "pify": {
@@ -6788,7 +6979,7 @@
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -6798,7 +6989,7 @@
             "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
             "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
             "requires": {
-                "foreachasync": "3.0.0"
+                "foreachasync": "^3.0.0"
             }
         },
         "wcwidth": {
@@ -6806,7 +6997,7 @@
             "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
             "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
             "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.3"
             }
         },
         "which": {
@@ -6814,7 +7005,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -6828,7 +7019,7 @@
             "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
             "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
         },
         "win-release": {
@@ -6836,7 +7027,7 @@
             "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
             "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.1"
             }
         },
         "windows-release": {
@@ -6844,7 +7035,7 @@
             "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
             "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
             "requires": {
-                "execa": "1.0.0"
+                "execa": "^1.0.0"
             }
         },
         "winston": {
@@ -6852,25 +7043,25 @@
             "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
             "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
             "requires": {
-                "async": "2.6.3",
-                "diagnostics": "1.1.1",
-                "is-stream": "1.1.0",
-                "logform": "2.1.2",
+                "async": "^2.6.1",
+                "diagnostics": "^1.1.1",
+                "is-stream": "^1.1.0",
+                "logform": "^2.1.1",
                 "one-time": "0.0.4",
-                "readable-stream": "3.4.0",
-                "stack-trace": "0.0.10",
-                "triple-beam": "1.3.0",
-                "winston-transport": "4.3.0"
+                "readable-stream": "^3.1.1",
+                "stack-trace": "0.0.x",
+                "triple-beam": "^1.3.0",
+                "winston-transport": "^4.3.0"
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-                    "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+                    "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
                     "requires": {
-                        "inherits": "2.0.4",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 }
             }
@@ -6880,8 +7071,8 @@
             "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
             "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
             "requires": {
-                "readable-stream": "2.3.7",
-                "triple-beam": "1.3.0"
+                "readable-stream": "^2.3.6",
+                "triple-beam": "^1.2.0"
             }
         },
         "with-open-file": {
@@ -6889,9 +7080,9 @@
             "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.7.tgz",
             "integrity": "sha512-ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==",
             "requires": {
-                "p-finally": "1.0.0",
-                "p-try": "2.2.0",
-                "pify": "4.0.1"
+                "p-finally": "^1.0.0",
+                "p-try": "^2.1.0",
+                "pify": "^4.0.1"
             },
             "dependencies": {
                 "p-try": {
@@ -6917,8 +7108,8 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -6931,7 +7122,7 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -6939,9 +7130,9 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -6949,7 +7140,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 }
             }
@@ -6965,7 +7156,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "write-file-atomic": {
@@ -6973,9 +7164,9 @@
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
             "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
             "requires": {
-                "graceful-fs": "4.2.3",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "xdg-basedir": {
@@ -6988,8 +7179,8 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
             "requires": {
-                "sax": "1.2.1",
-                "xmlbuilder": "9.0.7"
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
             }
         },
         "xmlbuilder": {
@@ -7025,19 +7216,19 @@
             "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.3",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "5.0.0"
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -7058,8 +7249,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "invert-kv": {
@@ -7074,7 +7265,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "lcid": {
@@ -7083,7 +7274,7 @@
                     "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                     "dev": true,
                     "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -7092,11 +7283,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.2.3",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "os-locale": {
@@ -7105,7 +7296,7 @@
                     "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                     "dev": true,
                     "requires": {
-                        "lcid": "1.0.0"
+                        "lcid": "^1.0.0"
                     }
                 },
                 "parse-json": {
@@ -7114,7 +7305,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -7123,7 +7314,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -7132,9 +7323,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.2.3",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -7149,9 +7340,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.5.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -7160,8 +7351,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -7170,9 +7361,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -7181,7 +7372,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-bom": {
@@ -7190,7 +7381,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "yargs-parser": {
@@ -7199,7 +7390,7 @@
                     "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0"
+                        "camelcase": "^3.0.0"
                     }
                 }
             }
@@ -7209,7 +7400,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
             "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
             "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
             }
         },
         "yeoman-assert": {
@@ -7223,7 +7414,7 @@
             "resolved": "https://registry.npmjs.org/yeoman-character/-/yeoman-character-1.1.0.tgz",
             "integrity": "sha1-kNS1vq+SdZCGF3AVsv36LgaE18c=",
             "requires": {
-                "supports-color": "3.2.3"
+                "supports-color": "^3.1.2"
             },
             "dependencies": {
                 "has-flag": {
@@ -7236,7 +7427,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -7246,16 +7437,16 @@
             "resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-4.0.0.tgz",
             "integrity": "sha512-CP0fwGk5Y+jel+A0AQbyqnIFZRRpkKOeYUibiTSmlgV9PcgNFFVwn86VcUIpDLOqVjF+9v+O9FWQMo+IUcV2mA==",
             "requires": {
-                "ansi-styles": "3.2.1",
-                "bin-version-check": "3.0.0",
-                "chalk": "2.4.1",
-                "global-agent": "2.1.7",
-                "global-tunnel-ng": "2.7.1",
-                "latest-version": "3.1.0",
-                "log-symbols": "2.2.0",
-                "semver": "5.5.0",
-                "twig": "1.14.0",
-                "user-home": "2.0.0"
+                "ansi-styles": "^3.2.0",
+                "bin-version-check": "^3.0.0",
+                "chalk": "^2.3.0",
+                "global-agent": "^2.0.0",
+                "global-tunnel-ng": "^2.5.3",
+                "latest-version": "^3.1.0",
+                "log-symbols": "^2.1.0",
+                "semver": "^5.0.3",
+                "twig": "^1.10.5",
+                "user-home": "^2.0.0"
             }
         },
         "yeoman-environment": {
@@ -7263,21 +7454,21 @@
             "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.0.tgz",
             "integrity": "sha512-PHSAkVOqYdcR+C+Uht1SGC4eVD/9OhygYFkYaI66xF8vKIeS1RNYay+umj2ZrQeJ50tF5Q/RSO6qGDz9y3Ifug==",
             "requires": {
-                "chalk": "2.4.1",
-                "cross-spawn": "6.0.5",
-                "debug": "3.1.0",
-                "diff": "3.5.0",
-                "escape-string-regexp": "1.0.5",
-                "globby": "8.0.2",
-                "grouped-queue": "0.3.3",
-                "inquirer": "5.2.0",
-                "is-scoped": "1.0.0",
-                "lodash": "4.17.13",
-                "log-symbols": "2.2.0",
-                "mem-fs": "1.1.3",
-                "strip-ansi": "4.0.0",
-                "text-table": "0.2.0",
-                "untildify": "3.0.3"
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "diff": "^3.3.1",
+                "escape-string-regexp": "^1.0.2",
+                "globby": "^8.0.1",
+                "grouped-queue": "^0.3.3",
+                "inquirer": "^5.2.0",
+                "is-scoped": "^1.0.0",
+                "lodash": "^4.17.10",
+                "log-symbols": "^2.1.0",
+                "mem-fs": "^1.1.0",
+                "strip-ansi": "^4.0.0",
+                "text-table": "^0.2.0",
+                "untildify": "^3.0.2"
             }
         },
         "yeoman-generator": {
@@ -7285,31 +7476,31 @@
             "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
             "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
             "requires": {
-                "async": "2.6.3",
-                "chalk": "2.4.1",
-                "cli-table": "0.3.1",
-                "cross-spawn": "6.0.5",
-                "dargs": "5.1.0",
-                "dateformat": "3.0.3",
-                "debug": "3.1.0",
-                "detect-conflict": "1.0.1",
-                "error": "7.2.1",
-                "find-up": "2.1.0",
-                "github-username": "4.1.0",
-                "istextorbinary": "2.6.0",
-                "lodash": "4.17.13",
-                "make-dir": "1.3.0",
-                "mem-fs-editor": "4.0.3",
-                "minimist": "1.2.0",
-                "pretty-bytes": "4.0.2",
-                "read-chunk": "2.1.0",
-                "read-pkg-up": "3.0.0",
-                "rimraf": "2.7.1",
-                "run-async": "2.3.0",
-                "shelljs": "0.8.2",
-                "text-table": "0.2.0",
-                "through2": "2.0.3",
-                "yeoman-environment": "2.3.0"
+                "async": "^2.6.0",
+                "chalk": "^2.3.0",
+                "cli-table": "^0.3.1",
+                "cross-spawn": "^6.0.5",
+                "dargs": "^5.1.0",
+                "dateformat": "^3.0.3",
+                "debug": "^3.1.0",
+                "detect-conflict": "^1.0.0",
+                "error": "^7.0.2",
+                "find-up": "^2.1.0",
+                "github-username": "^4.0.0",
+                "istextorbinary": "^2.2.1",
+                "lodash": "^4.17.10",
+                "make-dir": "^1.1.0",
+                "mem-fs-editor": "^4.0.0",
+                "minimist": "^1.2.0",
+                "pretty-bytes": "^4.0.2",
+                "read-chunk": "^2.1.0",
+                "read-pkg-up": "^3.0.0",
+                "rimraf": "^2.6.2",
+                "run-async": "^2.0.0",
+                "shelljs": "^0.8.0",
+                "text-table": "^0.2.0",
+                "through2": "^2.0.0",
+                "yeoman-environment": "^2.0.5"
             },
             "dependencies": {
                 "clone": {
@@ -7332,12 +7523,12 @@
                     "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
                     "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
                     "requires": {
-                        "array-union": "1.0.2",
-                        "dir-glob": "2.0.0",
-                        "glob": "7.1.2",
-                        "ignore": "3.3.10",
-                        "pify": "3.0.0",
-                        "slash": "1.0.0"
+                        "array-union": "^1.0.1",
+                        "dir-glob": "^2.0.0",
+                        "glob": "^7.1.2",
+                        "ignore": "^3.3.5",
+                        "pify": "^3.0.0",
+                        "slash": "^1.0.0"
                     }
                 },
                 "mem-fs-editor": {
@@ -7345,17 +7536,17 @@
                     "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
                     "integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
                     "requires": {
-                        "commondir": "1.0.1",
-                        "deep-extend": "0.6.0",
-                        "ejs": "2.6.1",
-                        "glob": "7.1.2",
-                        "globby": "7.1.1",
-                        "isbinaryfile": "3.0.3",
-                        "mkdirp": "0.5.1",
-                        "multimatch": "2.1.0",
-                        "rimraf": "2.7.1",
-                        "through2": "2.0.3",
-                        "vinyl": "2.2.0"
+                        "commondir": "^1.0.1",
+                        "deep-extend": "^0.6.0",
+                        "ejs": "^2.5.9",
+                        "glob": "^7.0.3",
+                        "globby": "^7.1.1",
+                        "isbinaryfile": "^3.0.2",
+                        "mkdirp": "^0.5.0",
+                        "multimatch": "^2.0.0",
+                        "rimraf": "^2.2.8",
+                        "through2": "^2.0.0",
+                        "vinyl": "^2.0.1"
                     }
                 },
                 "minimist": {
@@ -7373,8 +7564,8 @@
                     "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
                     "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
                     "requires": {
-                        "pify": "3.0.0",
-                        "safe-buffer": "5.1.2"
+                        "pify": "^3.0.0",
+                        "safe-buffer": "^5.1.1"
                     }
                 },
                 "replace-ext": {
@@ -7387,12 +7578,12 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.3",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -7403,14 +7594,14 @@
             "integrity": "sha512-4KFaEWcRhLq1QC9EtdU3Miw/QxlEcNcF4VfgQdQsTJOa2nSXL/NVsMTRoMkki7ssYQornCOqGgXJA5/VUICtcw==",
             "dev": true,
             "requires": {
-                "inquirer": "5.2.0",
-                "lodash": "4.17.13",
-                "mkdirp": "0.5.1",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.7.1",
-                "sinon": "5.1.1",
-                "yeoman-environment": "2.3.0",
-                "yeoman-generator": "2.0.5"
+                "inquirer": "^5.2.0",
+                "lodash": "^4.3.0",
+                "mkdirp": "^0.5.1",
+                "pinkie-promise": "^2.0.1",
+                "rimraf": "^2.4.4",
+                "sinon": "^5.0.7",
+                "yeoman-environment": "^2.0.0",
+                "yeoman-generator": "^2.0.5"
             },
             "dependencies": {
                 "sinon": {
@@ -7419,53 +7610,53 @@
                     "integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
                     "dev": true,
                     "requires": {
-                        "@sinonjs/formatio": "2.0.0",
-                        "diff": "3.5.0",
-                        "lodash.get": "4.4.2",
-                        "lolex": "2.7.5",
-                        "nise": "1.5.3",
-                        "supports-color": "5.5.0",
-                        "type-detect": "4.0.8"
+                        "@sinonjs/formatio": "^2.0.0",
+                        "diff": "^3.5.0",
+                        "lodash.get": "^4.4.2",
+                        "lolex": "^2.4.2",
+                        "nise": "^1.3.3",
+                        "supports-color": "^5.4.0",
+                        "type-detect": "^4.0.8"
                     }
                 }
             }
         },
         "yo": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/yo/-/yo-3.1.0.tgz",
-            "integrity": "sha512-boSESRRyvfyns3DfzxF2F0LVV97wSEFbKUi1oC7RwnZTA66KZ7Bo3JjOLe7mM6IjjeI0vEZcr4BbFjrSHh8d0Q==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yo/-/yo-3.1.1.tgz",
+            "integrity": "sha512-GFg4QC1xi3gkbHGGUFme8/8XPg3kDISu/qJfx56X207yuv1FSevGY/eKuym7kh0bniCB4n3rseWW+QZXPH8LIw==",
             "requires": {
-                "async": "2.6.3",
-                "chalk": "2.4.1",
-                "cli-list": "0.2.0",
-                "configstore": "3.1.2",
-                "cross-spawn": "6.0.5",
-                "figures": "2.0.0",
-                "fullname": "3.3.0",
-                "global-agent": "2.1.7",
-                "global-tunnel-ng": "2.7.1",
-                "got": "8.3.2",
-                "humanize-string": "1.0.2",
-                "inquirer": "6.5.2",
-                "insight": "0.10.3",
-                "lodash": "4.17.15",
-                "meow": "3.7.0",
-                "npm-keyword": "5.0.0",
-                "open": "6.4.0",
-                "package-json": "5.0.0",
-                "parse-help": "1.0.0",
-                "read-pkg-up": "4.0.0",
-                "root-check": "1.0.0",
-                "sort-on": "3.0.0",
-                "string-length": "2.0.0",
-                "tabtab": "1.3.2",
-                "titleize": "1.0.1",
-                "update-notifier": "2.5.0",
-                "user-home": "2.0.0",
-                "yeoman-character": "1.1.0",
-                "yeoman-doctor": "4.0.0",
-                "yeoman-environment": "2.7.0",
-                "yosay": "2.0.2"
+                "async": "^2.6.1",
+                "chalk": "^2.4.1",
+                "cli-list": "^0.2.0",
+                "configstore": "^3.1.2",
+                "cross-spawn": "^6.0.5",
+                "figures": "^2.0.0",
+                "fullname": "^4.0.1",
+                "global-agent": "^2.0.0",
+                "global-tunnel-ng": "^2.7.1",
+                "got": "^8.3.2",
+                "humanize-string": "^1.0.2",
+                "inquirer": "^6.0.0",
+                "insight": "^0.10.3",
+                "lodash": "^4.17.15",
+                "meow": "^3.0.0",
+                "npm-keyword": "^5.0.0",
+                "open": "^6.3.0",
+                "package-json": "^5.0.0",
+                "parse-help": "^1.0.0",
+                "read-pkg-up": "^4.0.0",
+                "root-check": "^1.0.0",
+                "sort-on": "^3.0.0",
+                "string-length": "^2.0.0",
+                "tabtab": "^1.3.2",
+                "titleize": "^1.0.1",
+                "update-notifier": "^2.5.0",
+                "user-home": "^2.0.0",
+                "yeoman-character": "^1.0.0",
+                "yeoman-doctor": "^4.0.0",
+                "yeoman-environment": "^2.4.0",
+                "yosay": "^2.0.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -7483,8 +7674,8 @@
                     "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "map-obj": "1.0.1"
+                        "camelcase": "^2.0.0",
+                        "map-obj": "^1.0.0"
                     }
                 },
                 "chardet": {
@@ -7497,11 +7688,11 @@
                     "resolved": "https://registry.npmjs.org/conf/-/conf-1.4.0.tgz",
                     "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
                     "requires": {
-                        "dot-prop": "4.2.0",
-                        "env-paths": "1.0.0",
-                        "make-dir": "1.3.0",
-                        "pkg-up": "2.0.0",
-                        "write-file-atomic": "2.4.3"
+                        "dot-prop": "^4.1.0",
+                        "env-paths": "^1.0.0",
+                        "make-dir": "^1.0.0",
+                        "pkg-up": "^2.0.0",
+                        "write-file-atomic": "^2.3.0"
                     }
                 },
                 "debug": {
@@ -7517,9 +7708,9 @@
                     "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
                     "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
                     "requires": {
-                        "chardet": "0.7.0",
-                        "iconv-lite": "0.4.24",
-                        "tmp": "0.0.33"
+                        "chardet": "^0.7.0",
+                        "iconv-lite": "^0.4.24",
+                        "tmp": "^0.0.33"
                     }
                 },
                 "find-up": {
@@ -7527,8 +7718,8 @@
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "get-stream": {
@@ -7541,23 +7732,23 @@
                     "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
                     "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
                     "requires": {
-                        "@sindresorhus/is": "0.7.0",
-                        "cacheable-request": "2.1.4",
-                        "decompress-response": "3.3.0",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "into-stream": "3.1.0",
-                        "is-retry-allowed": "1.2.0",
-                        "isurl": "1.0.0",
-                        "lowercase-keys": "1.0.1",
-                        "mimic-response": "1.0.1",
-                        "p-cancelable": "0.4.1",
-                        "p-timeout": "2.0.1",
-                        "pify": "3.0.0",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "url-parse-lax": "3.0.0",
-                        "url-to-options": "1.0.1"
+                        "@sindresorhus/is": "^0.7.0",
+                        "cacheable-request": "^2.1.1",
+                        "decompress-response": "^3.3.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "into-stream": "^3.1.0",
+                        "is-retry-allowed": "^1.1.0",
+                        "isurl": "^1.0.0-alpha5",
+                        "lowercase-keys": "^1.0.0",
+                        "mimic-response": "^1.0.0",
+                        "p-cancelable": "^0.4.0",
+                        "p-timeout": "^2.0.1",
+                        "pify": "^3.0.0",
+                        "safe-buffer": "^5.1.1",
+                        "timed-out": "^4.0.1",
+                        "url-parse-lax": "^3.0.0",
+                        "url-to-options": "^1.0.1"
                     }
                 },
                 "indent-string": {
@@ -7565,7 +7756,7 @@
                     "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "inquirer": {
@@ -7573,19 +7764,19 @@
                     "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
                     "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
                     "requires": {
-                        "ansi-escapes": "3.2.0",
-                        "chalk": "2.4.2",
-                        "cli-cursor": "2.1.0",
-                        "cli-width": "2.2.0",
-                        "external-editor": "3.1.0",
-                        "figures": "2.0.0",
-                        "lodash": "4.17.15",
+                        "ansi-escapes": "^3.2.0",
+                        "chalk": "^2.4.2",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.17.12",
                         "mute-stream": "0.0.7",
-                        "run-async": "2.3.0",
-                        "rxjs": "6.5.4",
-                        "string-width": "2.1.1",
-                        "strip-ansi": "5.2.0",
-                        "through": "2.3.8"
+                        "run-async": "^2.2.0",
+                        "rxjs": "^6.4.0",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^5.1.0",
+                        "through": "^2.3.6"
                     },
                     "dependencies": {
                         "chalk": {
@@ -7593,9 +7784,9 @@
                             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
                             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                             "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
+                                "ansi-styles": "^3.2.1",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^5.3.0"
                             }
                         }
                     }
@@ -7605,15 +7796,15 @@
                     "resolved": "https://registry.npmjs.org/insight/-/insight-0.10.3.tgz",
                     "integrity": "sha512-YOncxSN6Omh+1Oqxt+OJAvJVMDKw7l6IEG0wT2cTMGxjsTcroOGW4IR926QDzxg/uZHcFZ2cZbckDWdZhc2pZw==",
                     "requires": {
-                        "async": "2.6.3",
-                        "chalk": "2.4.2",
-                        "conf": "1.4.0",
-                        "inquirer": "6.5.2",
-                        "lodash.debounce": "4.0.8",
-                        "os-name": "3.1.0",
-                        "request": "2.88.0",
-                        "tough-cookie": "3.0.1",
-                        "uuid": "3.3.3"
+                        "async": "^2.6.2",
+                        "chalk": "^2.4.2",
+                        "conf": "^1.4.0",
+                        "inquirer": "^6.3.1",
+                        "lodash.debounce": "^4.0.8",
+                        "os-name": "^3.1.0",
+                        "request": "^2.88.0",
+                        "tough-cookie": "^3.0.1",
+                        "uuid": "^3.3.2"
                     },
                     "dependencies": {
                         "chalk": {
@@ -7621,9 +7812,9 @@
                             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
                             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                             "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
+                                "ansi-styles": "^3.2.1",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^5.3.0"
                             }
                         }
                     }
@@ -7633,7 +7824,7 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -7641,11 +7832,11 @@
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "requires": {
-                        "graceful-fs": "4.2.3",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     },
                     "dependencies": {
                         "pify": {
@@ -7660,8 +7851,8 @@
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "requires": {
-                        "p-locate": "3.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     },
                     "dependencies": {
                         "path-exists": {
@@ -7691,16 +7882,16 @@
                     "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "requires": {
-                        "camelcase-keys": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "loud-rejection": "1.6.0",
-                        "map-obj": "1.0.1",
-                        "minimist": "1.2.0",
-                        "normalize-package-data": "2.5.0",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "redent": "1.0.0",
-                        "trim-newlines": "1.0.0"
+                        "camelcase-keys": "^2.0.0",
+                        "decamelize": "^1.1.2",
+                        "loud-rejection": "^1.0.0",
+                        "map-obj": "^1.0.1",
+                        "minimist": "^1.1.3",
+                        "normalize-package-data": "^2.3.4",
+                        "object-assign": "^4.0.1",
+                        "read-pkg-up": "^1.0.1",
+                        "redent": "^1.0.0",
+                        "trim-newlines": "^1.0.0"
                     },
                     "dependencies": {
                         "read-pkg-up": {
@@ -7708,8 +7899,8 @@
                             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                             "requires": {
-                                "find-up": "1.1.2",
-                                "read-pkg": "1.1.0"
+                                "find-up": "^1.0.0",
+                                "read-pkg": "^1.0.0"
                             }
                         }
                     }
@@ -7729,8 +7920,8 @@
                     "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
                     "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
                     "requires": {
-                        "macos-release": "2.3.0",
-                        "windows-release": "3.2.0"
+                        "macos-release": "^2.2.0",
+                        "windows-release": "^3.1.0"
                     }
                 },
                 "p-cancelable": {
@@ -7743,7 +7934,7 @@
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
                     "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
                     "requires": {
-                        "p-try": "2.2.0"
+                        "p-try": "^2.0.0"
                     }
                 },
                 "p-locate": {
@@ -7751,7 +7942,7 @@
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                     "requires": {
-                        "p-limit": "2.2.2"
+                        "p-limit": "^2.0.0"
                     }
                 },
                 "p-timeout": {
@@ -7759,7 +7950,7 @@
                     "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
                     "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
                     "requires": {
-                        "p-finally": "1.0.0"
+                        "p-finally": "^1.0.0"
                     }
                 },
                 "p-try": {
@@ -7772,7 +7963,7 @@
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -7780,7 +7971,7 @@
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -7788,9 +7979,9 @@
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "requires": {
-                        "graceful-fs": "4.2.3",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     },
                     "dependencies": {
                         "pify": {
@@ -7815,9 +8006,9 @@
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.5.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -7825,8 +8016,8 @@
                     "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
                     "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
                     "requires": {
-                        "find-up": "3.0.0",
-                        "read-pkg": "3.0.0"
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^3.0.0"
                     },
                     "dependencies": {
                         "find-up": {
@@ -7834,7 +8025,7 @@
                             "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
                             "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                             "requires": {
-                                "locate-path": "3.0.0"
+                                "locate-path": "^3.0.0"
                             }
                         },
                         "load-json-file": {
@@ -7842,10 +8033,10 @@
                             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
                             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                             "requires": {
-                                "graceful-fs": "4.2.3",
-                                "parse-json": "4.0.0",
-                                "pify": "3.0.0",
-                                "strip-bom": "3.0.0"
+                                "graceful-fs": "^4.1.2",
+                                "parse-json": "^4.0.0",
+                                "pify": "^3.0.0",
+                                "strip-bom": "^3.0.0"
                             }
                         },
                         "parse-json": {
@@ -7853,8 +8044,8 @@
                             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
                             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                             "requires": {
-                                "error-ex": "1.3.2",
-                                "json-parse-better-errors": "1.0.2"
+                                "error-ex": "^1.3.1",
+                                "json-parse-better-errors": "^1.0.1"
                             }
                         },
                         "path-type": {
@@ -7862,7 +8053,7 @@
                             "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
                             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                             "requires": {
-                                "pify": "3.0.0"
+                                "pify": "^3.0.0"
                             }
                         },
                         "read-pkg": {
@@ -7870,9 +8061,9 @@
                             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
                             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                             "requires": {
-                                "load-json-file": "4.0.0",
-                                "normalize-package-data": "2.5.0",
-                                "path-type": "3.0.0"
+                                "load-json-file": "^4.0.0",
+                                "normalize-package-data": "^2.3.2",
+                                "path-type": "^3.0.0"
                             }
                         },
                         "strip-bom": {
@@ -7887,8 +8078,8 @@
                     "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                     "requires": {
-                        "indent-string": "2.1.0",
-                        "strip-indent": "1.0.1"
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
                     }
                 },
                 "restore-cursor": {
@@ -7896,8 +8087,8 @@
                     "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                     "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
                     "requires": {
-                        "exit-hook": "1.1.1",
-                        "onetime": "1.1.0"
+                        "exit-hook": "^1.0.0",
+                        "onetime": "^1.0.0"
                     }
                 },
                 "rxjs": {
@@ -7905,7 +8096,7 @@
                     "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
                     "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
                     "requires": {
-                        "tslib": "1.10.0"
+                        "tslib": "^1.9.0"
                     }
                 },
                 "strip-ansi": {
@@ -7913,7 +8104,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "requires": {
-                        "ansi-regex": "4.1.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 },
                 "strip-bom": {
@@ -7921,7 +8112,7 @@
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-indent": {
@@ -7929,7 +8120,7 @@
                     "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                     "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                     }
                 },
                 "tabtab": {
@@ -7937,12 +8128,12 @@
                     "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-1.3.2.tgz",
                     "integrity": "sha1-u5wspjJPZZ/edjTCyvPAluEYfKc=",
                     "requires": {
-                        "debug": "2.6.9",
-                        "inquirer": "1.2.3",
-                        "minimist": "1.2.0",
-                        "mkdirp": "0.5.1",
-                        "npmlog": "2.0.4",
-                        "object-assign": "4.1.1"
+                        "debug": "^2.2.0",
+                        "inquirer": "^1.0.2",
+                        "minimist": "^1.2.0",
+                        "mkdirp": "^0.5.1",
+                        "npmlog": "^2.0.3",
+                        "object-assign": "^4.1.0"
                     },
                     "dependencies": {
                         "ansi-escapes": {
@@ -7965,11 +8156,11 @@
                             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                             "requires": {
-                                "ansi-styles": "2.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "has-ansi": "2.0.0",
-                                "strip-ansi": "3.0.1",
-                                "supports-color": "2.0.0"
+                                "ansi-styles": "^2.2.1",
+                                "escape-string-regexp": "^1.0.2",
+                                "has-ansi": "^2.0.0",
+                                "strip-ansi": "^3.0.0",
+                                "supports-color": "^2.0.0"
                             }
                         },
                         "cli-cursor": {
@@ -7977,7 +8168,7 @@
                             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
                             "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
                             "requires": {
-                                "restore-cursor": "1.0.1"
+                                "restore-cursor": "^1.0.1"
                             }
                         },
                         "external-editor": {
@@ -7985,9 +8176,9 @@
                             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
                             "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
                             "requires": {
-                                "extend": "3.0.2",
-                                "spawn-sync": "1.0.15",
-                                "tmp": "0.0.29"
+                                "extend": "^3.0.0",
+                                "spawn-sync": "^1.0.15",
+                                "tmp": "^0.0.29"
                             }
                         },
                         "figures": {
@@ -7995,8 +8186,8 @@
                             "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
                             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
                             "requires": {
-                                "escape-string-regexp": "1.0.5",
-                                "object-assign": "4.1.1"
+                                "escape-string-regexp": "^1.0.5",
+                                "object-assign": "^4.1.0"
                             }
                         },
                         "inquirer": {
@@ -8004,20 +8195,20 @@
                             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
                             "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
                             "requires": {
-                                "ansi-escapes": "1.4.0",
-                                "chalk": "1.1.3",
-                                "cli-cursor": "1.0.2",
-                                "cli-width": "2.2.0",
-                                "external-editor": "1.1.1",
-                                "figures": "1.7.0",
-                                "lodash": "4.17.15",
+                                "ansi-escapes": "^1.1.0",
+                                "chalk": "^1.0.0",
+                                "cli-cursor": "^1.0.1",
+                                "cli-width": "^2.0.0",
+                                "external-editor": "^1.1.0",
+                                "figures": "^1.3.5",
+                                "lodash": "^4.3.0",
                                 "mute-stream": "0.0.6",
-                                "pinkie-promise": "2.0.1",
-                                "run-async": "2.3.0",
-                                "rx": "4.1.0",
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "through": "2.3.8"
+                                "pinkie-promise": "^2.0.0",
+                                "run-async": "^2.2.0",
+                                "rx": "^4.1.0",
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.0",
+                                "through": "^2.3.6"
                             }
                         },
                         "mute-stream": {
@@ -8030,9 +8221,9 @@
                             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         },
                         "strip-ansi": {
@@ -8040,7 +8231,7 @@
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "requires": {
-                                "ansi-regex": "2.1.1"
+                                "ansi-regex": "^2.0.0"
                             }
                         },
                         "supports-color": {
@@ -8053,7 +8244,7 @@
                             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
                             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
                             "requires": {
-                                "os-tmpdir": "1.0.2"
+                                "os-tmpdir": "~1.0.1"
                             }
                         }
                     }
@@ -8063,9 +8254,9 @@
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
                     "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
                     "requires": {
-                        "ip-regex": "2.1.0",
-                        "psl": "1.7.0",
-                        "punycode": "2.1.1"
+                        "ip-regex": "^2.1.0",
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
                     }
                 },
                 "trim-newlines": {
@@ -8078,7 +8269,7 @@
                     "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
                     "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
                     "requires": {
-                        "prepend-http": "2.0.0"
+                        "prepend-http": "^2.0.0"
                     }
                 },
                 "yeoman-environment": {
@@ -8086,21 +8277,21 @@
                     "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.7.0.tgz",
                     "integrity": "sha512-YNzSUWgJVSgnm0qgLON4Gb2nTm+kywBiWjK4MbvosjUP2YJJ30lNhEx7ukyzKRPUlsavd5IsuALtF6QaVrq81A==",
                     "requires": {
-                        "chalk": "2.4.1",
-                        "cross-spawn": "6.0.5",
-                        "debug": "3.2.6",
-                        "diff": "3.5.0",
-                        "escape-string-regexp": "1.0.5",
-                        "globby": "8.0.2",
-                        "grouped-queue": "0.3.3",
-                        "inquirer": "6.5.2",
-                        "is-scoped": "1.0.0",
-                        "lodash": "4.17.15",
-                        "log-symbols": "2.2.0",
-                        "mem-fs": "1.1.3",
-                        "strip-ansi": "4.0.0",
-                        "text-table": "0.2.0",
-                        "untildify": "3.0.3"
+                        "chalk": "^2.4.1",
+                        "cross-spawn": "^6.0.5",
+                        "debug": "^3.1.0",
+                        "diff": "^3.5.0",
+                        "escape-string-regexp": "^1.0.2",
+                        "globby": "^8.0.1",
+                        "grouped-queue": "^0.3.3",
+                        "inquirer": "^6.0.0",
+                        "is-scoped": "^1.0.0",
+                        "lodash": "^4.17.10",
+                        "log-symbols": "^2.2.0",
+                        "mem-fs": "^1.1.0",
+                        "strip-ansi": "^4.0.0",
+                        "text-table": "^0.2.0",
+                        "untildify": "^3.0.3"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -8113,7 +8304,7 @@
                             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
                             "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                             "requires": {
-                                "ms": "2.1.2"
+                                "ms": "^2.1.1"
                             }
                         },
                         "ms": {
@@ -8126,7 +8317,7 @@
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -8138,15 +8329,15 @@
             "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz",
             "integrity": "sha512-avX6nz2esp7IMXGag4gu6OyQBsMh/SEn+ZybGu3yKPlOTE6z9qJrzG/0X5vCq/e0rPFy0CUYCze0G5hL310ibA==",
             "requires": {
-                "ansi-regex": "2.1.1",
-                "ansi-styles": "3.2.1",
-                "chalk": "1.1.3",
-                "cli-boxes": "1.0.0",
+                "ansi-regex": "^2.0.0",
+                "ansi-styles": "^3.0.0",
+                "chalk": "^1.0.0",
+                "cli-boxes": "^1.0.0",
                 "pad-component": "0.0.1",
-                "string-width": "2.1.1",
-                "strip-ansi": "3.0.1",
-                "taketalk": "1.0.0",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "taketalk": "^1.0.0",
+                "wrap-ansi": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -8159,11 +8350,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "ansi-styles": {
@@ -8178,7 +8369,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "supports-color": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "semver": "5.5.0",
         "shelljs": "0.8.2",
         "through2": "2.0.3",
-        "generator-jhipster": "6.6.0",
+        "generator-jhipster": "6.7.0",
         "yeoman-environment": "2.3.0",
         "yeoman-generator": "2.0.5"
     },


### PR DESCRIPTION
Motivation:
When running JHipster, a warning message was trown becase the
`generator-hipster` dependency version is not the latest.

Modification:
Change to the latest version.