### PR TITLE
Update entity generation to match refactored entity base methods

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable consistent-return */
 const chalk = require('chalk');
 const EntityGenerator = require('generator-jhipster/generators/entity');
+const _ = require('lodash');
 const prompts = require('./prompts');
 const constants = require('../generator-quarkus-constants');
 
@@ -17,7 +18,8 @@ module.exports = class extends EntityGenerator {
         this.configOptions = jhContext.configOptions || {};
 
         // This sets up options for this sub generator and is being reused from JHipster
-        jhContext.setupEntityOptions(this, jhContext, this);
+        const name = _.upperFirst(this.options.name).replace('.json', '');
+        this.entityStorage = jhContext.getEntityConfig(name);
     }
 
     get initializing() {


### PR DESCRIPTION
Update entity generation to match refactored entity base methods so that quarkus master works against generator-jhipster master.

This PR brings the quarkus blueprint master entity generation in sync with JHipster base. Without this entity generation fails if using the latest of both. 