### PR TITLE
Remove contributor references

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,10 @@ jhipster -d --blueprint quarkus
 
 ✅ JDL import - `jhipster --blueprints quarkus import-jdl sample.jh`
 
-# Contributors ✨
+# ❤️ for community
 
-Thanks goes to these wonderful people:
-
-<table><tr><td  align="center"><a  href="https://github.com/danielpetisme"><img  src="https://avatars3.githubusercontent.com/u/593564?s=400&v=4"  width="100px;"  alt="Daniel Petisme (founder stream lead)"/><br/><sub><b>Daniel Petisme</b><br/><b>(founder stream lead)</b></sub></a></td><td  align="center"><a  href="https://github.com/amanganiello90"><img  src="https://avatars3.githubusercontent.com/u/20536757?s=400&v=4"  width="100px;"  alt="Angelo Manganiello"/><br  /><sub><b>Angelo Manganiello</b></sub></a></td></tr></table>
+Interested in contributing?
+Check out [JHipster contributing guide](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) to get started.
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
         "email": "daniel@jhipster.tech",
         "url": ""
     },
-    "contributors": [
-        "Angelo Manganiello <angelo.mang@libero.it> (https://github.com/amanganiello90)"
-    ],
     "files": [
         "generators"
     ],


### PR DESCRIPTION
As we can't handle all the contributors name on a project such like JHipster and blueprints, I suggest to remove the contributors mentions.

I also suggest to add a link to the contributing guide from the main project. Btw we could write a specific guide for Quarkus (that can inherit from the main one).

If we want to know who has already contribute to the project, we could access to GitHub insight: https://github.com/jhipster/jhipster-quarkus/graphs/contributors